### PR TITLE
Update pyproject.json's poetry schema

### DIFF
--- a/taplo-ide/schemas/pyproject.json
+++ b/taplo-ide/schemas/pyproject.json
@@ -1,307 +1,350 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Poetry": {
-      "title": "Poetry",
-      "description": "Configuration for [Poetry](https://python-poetry.org/).\n",
-      "evenBetterToml": {
-        "links": {
-          "key": "https://python-poetry.org/docs/pyproject/"
-        }
-      },
+    "poetry-authors": {
+      "type": "array",
+      "description": "List of authors that contributed to the package. This is typically the main maintainers, not the full list.",
+      "items": {
+        "type": "string",
+        "pattern": "^(?:\\S+?\\s)+?(?:<(?:[a-z\\d!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z\\d!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z\\d](?:[a-z\\d-]*[a-z\\d])?\\.)+[a-z\\d](?:[a-z\\d-]*[a-z\\d])?|\\[(?:(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?)\\.){3}(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?|[a-z\\d-]*[a-z\\d]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])>)?$"
+      }
+    },
+    "poetry-maintainers": {
+      "type": "array",
+      "description": "List of maintainers, other than the original author(s), that upkeep the package.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "poetry-dependencies": {
       "type": "object",
-      "required": [
-        "name",
-        "version",
-        "description",
-        "authors"
-      ],
+      "patternProperties": {
+        "^[a-zA-Z-_.0-9]+$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/poetry-dependency"
+            },
+            {
+              "$ref": "#/definitions/poetry-long-dependency"
+            },
+            {
+              "$ref": "#/definitions/poetry-git-dependency"
+            },
+            {
+              "$ref": "#/definitions/poetry-file-dependency"
+            },
+            {
+              "$ref": "#/definitions/poetry-path-dependency"
+            },
+            {
+              "$ref": "#/definitions/poetry-url-dependency"
+            },
+            {
+              "$ref": "#/definitions/poetry-multiple-constraints-dependency"
+            }
+          ]
+        }
+      }
+    },
+    "poetry-dependency": {
+      "type": "string",
+      "description": "The constraint of the dependency.",
+      "pattern": "v?(?:(?:(?:[0-9]+)!)?(?:[0-9]+(?:\\.[0-9]+)*)(?:[-_\\.]?(?:(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?:[0-9]+)?)?(?:(?:-(?:[0-9]+))|(?:[-_\\.]?(?:post|rev|r)[-_\\.]?(?:[0-9]+)?))?(?:[-_\\.]?(?:dev)[-_\\.]?(?:[0-9]+)?)?)(?:\\+(?:[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?"
+    },
+    "poetry-long-dependency": {
+      "type": "object",
+      "required": ["version"],
+      "additionalProperties": false,
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the package.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#name"
-            }
-          }
-        },
-        "description": {
-          "type": "string",
-          "description": "A short description of the package.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#description"
-            }
-          }
-        },
         "version": {
           "type": "string",
-          "description": "The version of the package.\n\nThis should follow [semantic versioning](https://semver.org). However it will not be enforced and you remain free to follow another specification.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#version"
-            }
-          }
+          "description": "The constraint of the dependency.",
+          "pattern": "v?(?:(?:(?:[0-9]+)!)?(?:[0-9]+(?:\\.[0-9]+)*)(?:[-_\\.]?(?:(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?:[0-9]+)?)?(?:(?:-(?:[0-9]+))|(?:[-_\\.]?(?:post|rev|r)[-_\\.]?(?:[0-9]+)?))?(?:[-_\\.]?(?:dev)[-_\\.]?(?:[0-9]+)?)?)(?:\\+(?:[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?"
         },
-        "license": {
+        "python": {
           "type": "string",
-          "description": "The license of the package.\n\nThe recommended notation for the most common licenses is (alphabetical):\n- Apache-2.0\n- BSD-2-Clause\n- BSD-3-Clause\n- BSD-4-Clause\n- GPL-2.0-only\n- GPL-2.0-or-later\n- GPL-3.0-only\n- GPL-3.0-or-later\n- LGPL-2.1-only\n- LGPL-2.1-or-later\n- LGPL-3.0-only\n- LGPL-3.0-or-later\n- MIT\n\nOptional, but it is highly recommended to supply this.\n\nIf your project is proprietary and does not use a specific licence, you can set this value as Proprietary.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#license"
-            }
-          }
+          "description": "The python versions for which the dependency should be installed."
         },
-        "authors": {
+        "platform": {
+          "type": "string",
+          "description": "The platform(s) for which the dependency should be installed."
+        },
+        "markers": {
+          "type": "string",
+          "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+        },
+        "allow-prereleases": {
+          "type": "boolean",
+          "description": "Whether the dependency allows prereleases or not."
+        },
+        "allows-prereleases": {
+          "type": "boolean",
+          "description": "Whether the dependency allows prereleases or not."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether the dependency is optional or not."
+        },
+        "extras": {
           "type": "array",
-          "description": "The authors of the package.\n\nThis is a list of authors and should contain at least one author. Authors must be in the form `name <email>`.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#authors"
-            }
-          },
-          "items": {
-            "type": "string",
-            "pattern": "^.*\\s(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
-          }
-        },
-        "maintainers": {
-          "type": "array",
-          "description": "The maintainers of the package. \n\nThis is a list of maintainers and should be distinct from authors. Maintainers may contain an email and be in the form `name <email>`.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#maintainers"
-            }
-          },
-          "items": {
-            "type": "string",
-            "pattern": "^.*\\s(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
-          }
-        },
-        "readme": {
-          "type": "string",
-          "description": "The readme file of the package.\nThe file could be either `README.rst` or `README.md`.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#readme"
-            }
-          }
-        },
-        "homepage": {
-          "type": "string",
-          "description": "An URL to the website of the project.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#homepage"
-            }
-          }
-        },
-        "repository": {
-          "type": "string",
-          "description": "An URL to the repository of the project.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#repository"
-            }
-          }
-        },
-        "documentation": {
-          "type": "string",
-          "description": "An URL to the documentation of the project.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#documentation"
-            }
-          }
-        },
-        "keywords": {
-          "type": "array",
-          "description": "A list of keywords (max: 5) that the package is related to.\n",
+          "description": "The required extras for this dependency.",
           "items": {
             "type": "string"
-          },
-          "maxItems": 5,
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#keywords"
-            }
-          }
-        },
-        "classifiers": {
-          "type": "array",
-          "description": "A list of PyPI [trove classifiers](https://pypi.org/classifiers/) that describe the project. \n\n```toml\n[tool.poetry]\n# ...\nclassifiers = [\n    \"Topic :: Software Development :: Build Tools\",\n    \"Topic :: Software Development :: Libraries :: Python Modules\"\n]\n\nNote that Python classifiers are still automatically added for you and are determined by your `python` requirement.\n\nThe `license` property will also set the License classifier automatically.\n```\n",
-          "items": {
-            "type": "string"
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#classifiers"
-            }
-          }
-        },
-        "packages": {
-          "type": "array",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#packages"
-            }
-          },
-          "description": "A list of packages and modules to include in the final distribution.\n\nIf your project structure differs from the standard one supported by poetry, you can specify the packages you want to include in the final distribution.\n\n```toml\n[tool.poetry]\n# ...\npackages = [\n    { include = \"my_package\" },\n    { include = \"extra_package/**/*.py\" },\n]\n\nIf your package is stored inside a \"source\" directory, you must specify it:\n\n```toml\n[tool.poetry]\n# ...\npackages = [\n    { include = \"my_package\", from = \"lib\" },\n]\n```\n\nIf you want to restrict a package to a specific build format you can specify it by using `format`:\n\n```toml\n[tool.poetry]\n# ...\npackages = [\n    { include = \"my_package\" },\n    { include = \"my_other_package\", format = \"sdist\" },\n]\n```\n\nUsing `packages` disables the package auto-detection feature meaning you have to explicitly specify the \"default\" package.\n\nPoetry is clever enough to detect Python subpackages.\n\nThus, you only have to specify the directory where your root package resides.\n```\n",
-          "items": {
-            "$ref": "#/definitions/Package"
-          }
-        },
-        "include": {
-          "type": "array",
-          "description": "A list of patterns that will be included in the final package.\n\nYou can explicitly specify to Poetry that a set of globs should be ignored or included for the purposes of packaging.\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#include-and-exclude"
-            }
-          },
-          "items": {
-            "type": "string"
-          }
-        },
-        "exclude": {
-          "type": "array",
-          "description": "A list of patterns that will excluded from the final package.\n\nThe globs specified in the exclude field identify a set of files that are not included when a package is built.\n\nIf a VCS is being used for a package, the exclude field will be seeded with the VCS’ ignore settings (`.gitignore` for git for example).\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#include-and-exclude"
-            }
-          },
-          "items": {
-            "type": "string"
-          }
-        },
-        "dependencies": {
-          "type": "object",
-          "description": "The dependencies of the package.\nPoetry is configured to look for dependencies on PyPi by default. Only the name and a version string are required in this case.",
-          "required": [
-            "python"
-          ],
-          "properties": {
-            "python": {
-              "type": "string",
-              "default": "^3",
-              "pattern": "^((((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)+)(,\\s*(((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)))*|(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)$"
-            }
-          },
-          "additionalProperties": {
-            "type": "string",
-            "pattern": "^((((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)+)(,\\s*(((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)))*|(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)$"
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies"
-            }
-          }
-        },
-        "dev-dependencies": {
-          "type": "object",
-          "description": "The dev-dependencies of the package.\nPoetry is configured to look for dependencies on PyPi by default. Only the name and a version string are required in this case.",
-          "required": [
-            "python"
-          ],
-          "properties": {
-            "python": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": {
-            "type": "string"
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies"
-            }
           }
         },
         "source": {
-          "type": "array",
-          "description": "Additional sources of dependencies.\n",
-          "items": {
-            "type": "object",
-            "description": "A dependency source.",
-            "required": [
-              "name",
-              "url"
-            ],
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "The name of the source."
-              },
-              "url": {
-                "type": "string",
-                "description": "The source URL."
-              }
-            }
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies"
-            }
-          }
+          "type": "string",
+          "description": "The exclusive source used to search for this dependency."
+        }
+      }
+    },
+    "poetry-git-dependency": {
+      "type": "object",
+      "required": ["git"],
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "type": "string",
+          "description": "The url of the git repository.",
+          "format": "uri"
         },
-        "scripts": {
-          "type": "object",
-          "description": "Scripts or executable that will be installed when installing the package.\n```toml [tool.poetry.scripts] poetry = 'poetry.console:run' ```\nHere, we will have the poetry script installed which will execute `console.run` in the `poetry` package.",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#scripts"
-            }
-          }
+        "branch": {
+          "type": "string",
+          "description": "The branch to checkout."
+        },
+        "tag": {
+          "type": "string",
+          "description": "The tag to checkout."
+        },
+        "rev": {
+          "type": "string",
+          "description": "The revision to checkout."
+        },
+        "python": {
+          "type": "string",
+          "description": "The python versions for which the dependency should be installed."
+        },
+        "platform": {
+          "type": "string",
+          "description": "The platform(s) for which the dependency should be installed."
+        },
+        "markers": {
+          "type": "string",
+          "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+        },
+        "allow-prereleases": {
+          "type": "boolean",
+          "description": "Whether the dependency allows prereleases or not."
+        },
+        "allows-prereleases": {
+          "type": "boolean",
+          "description": "Whether the dependency allows prereleases or not."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether the dependency is optional or not."
         },
         "extras": {
-          "type": "object",
-          "description": "Poetry supports extras to allow expression of:\n- optional dependencies, which enhance a package, but are not required; and\n- clusters of optional dependencies.\n\n```toml          \n[tool.poetry]\nname = \"awesome\"\n\n[tool.poetry.dependencies]\n# These packages are mandatory and form the core of this package’s distribution.\nmandatory = \"^1.0\"\n\n# A list of all of the optional dependencies, some of which are included in the\n# below `extras`. They can be opted into by apps.\npsycopg2 = { version = \"^2.7\", optional = true }\nmysqlclient = { version = \"^1.3\", optional = true }\n\n[tool.poetry.extras]\nmysql = [\"mysqlclient\"]\npgsql = [\"psycopg2\"]\n```\n\nWhen installing packages, you can specify extras by using the `-E|--extras` option:\n```\npoetry install --extras \"mysql pgsql\"\npoetry install -E mysql -E pgsql\n```\n",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#extras"
-            }
-          }
-        },
-        "plugins": {
-          "type": "object",
-          "description": "Poetry supports arbitrary plugins which work similarly to setuptools entry points. To match the example in the setuptools documentation, you would use the following:\n```toml\n[tool.poetry.plugins] # Optional super table\n\n[tool.poetry.plugins.\"blogtool.parsers\"]\n\".rst\" = \"some_module:SomeClass\"          \n```\n",
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#plugins"
-            }
-          },
-          "additionalProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        },
-        "urls": {
-          "type": "object",
-          "description": "In addition to the basic urls (homepage, repository and documentation), you can specify any custom url in the urls section.\n\n```toml\n[tool.poetry.urls]\n\"Bug Tracker\" = \"https://github.com/python-poetry/poetry/issues\"\n```\n\nIf you publish you package on PyPI, they will appear in the `Project Links` section.\n",
-          "additionalProperties": {
+          "type": "array",
+          "description": "The required extras for this dependency.",
+          "items": {
             "type": "string"
-          },
-          "evenBetterToml": {
-            "links": {
-              "key": "https://python-poetry.org/docs/pyproject/#urls"
-            }
           }
         }
       }
     },
+    "poetry-file-dependency": {
+      "type": "object",
+      "required": ["file"],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "The path to the file."
+        },
+        "python": {
+          "type": "string",
+          "description": "The python versions for which the dependency should be installed."
+        },
+        "platform": {
+          "type": "string",
+          "description": "The platform(s) for which the dependency should be installed."
+        },
+        "markers": {
+          "type": "string",
+          "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether the dependency is optional or not."
+        },
+        "extras": {
+          "type": "array",
+          "description": "The required extras for this dependency.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "poetry-path-dependency": {
+      "type": "object",
+      "required": ["path"],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The path to the dependency."
+        },
+        "python": {
+          "type": "string",
+          "description": "The python versions for which the dependency should be installed."
+        },
+        "platform": {
+          "type": "string",
+          "description": "The platform(s) for which the dependency should be installed."
+        },
+        "markers": {
+          "type": "string",
+          "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether the dependency is optional or not."
+        },
+        "extras": {
+          "type": "array",
+          "description": "The required extras for this dependency.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "develop": {
+          "type": "boolean",
+          "description": "Whether to install the dependency in development mode."
+        }
+      }
+    },
+    "poetry-url-dependency": {
+      "type": "object",
+      "required": ["url"],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The url to the file."
+        },
+        "python": {
+          "type": "string",
+          "description": "The python versions for which the dependency should be installed."
+        },
+        "platform": {
+          "type": "string",
+          "description": "The platform(s) for which the dependency should be installed."
+        },
+        "markers": {
+          "type": "string",
+          "description": "The PEP 508 compliant environment markers for which the dependency should be installed."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether the dependency is optional or not."
+        },
+        "extras": {
+          "type": "array",
+          "description": "The required extras for this dependency.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "poetry-multiple-constraints-dependency": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/poetry-dependency"
+          },
+          {
+            "$ref": "#/definitions/poetry-long-dependency"
+          },
+          {
+            "$ref": "#/definitions/poetry-git-dependency"
+          },
+          {
+            "$ref": "#/definitions/poetry-file-dependency"
+          },
+          {
+            "$ref": "#/definitions/poetry-path-dependency"
+          },
+          {
+            "$ref": "#/definitions/poetry-url-dependency"
+          }
+        ]
+      }
+    },
+    "poetry-scripts": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z-_.0-9]+$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/poetry-script"
+            },
+            {
+              "$ref": "#/definitions/poetry-extra-script"
+            }
+          ]
+        }
+      }
+    },
+    "poetry-script": {
+      "type": "string",
+      "description": "A simple script pointing to a callable object."
+    },
+    "poetry-extra-script": {
+      "type": "object",
+      "description": "A script that should be installed only if extras are activated.",
+      "additionalProperties": false,
+      "properties": {
+        "callable": {
+          "$ref": "#/definitions/poetry-script"
+        },
+        "extras": {
+          "type": "array",
+          "description": "The required extras for this script.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "poetry-repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the repository"
+        },
+        "url": {
+          "type": "string",
+          "description": "The url of the repository",
+          "format": "uri"
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Make this repository the default (disable PyPI)"
+        },
+        "secondary": {
+          "type": "boolean",
+          "description": "Declare this repository as secondary, i.e. it will only be looked up last for packages."
+        }
+      }
+    },
+
     "BuildSystem": {
       "title": "Build System",
       "type": "object",
@@ -311,9 +354,7 @@
         }
       },
       "description": "Build-related data.\n",
-      "required": [
-        "requires"
-      ],
+      "required": ["requires"],
       "properties": {
         "requires": {
           "description": "A list of strings representing [PEP 508](https://www.python.org/dev/peps/pep-0508) dependencies required to execute the build system.\n",
@@ -337,28 +378,6 @@
           }
         }
       }
-    },
-    "Package": {
-      "title": "Package",
-      "type": "object",
-      "description": "A package to include with Poetry.\n",
-      "required": [
-        "include"
-      ],
-      "properties": {
-        "include": {
-          "description": "A package name or glob pattern to the package.\n",
-          "type": "string"
-        },
-        "from": {
-          "description": "The directory of the package.\n",
-          "type": "string"
-        },
-        "format": {
-          "description": "Build format for the package.\n",
-          "type": "string"
-        }
-      }
     }
   },
   "type": "object",
@@ -377,7 +396,181 @@
       },
       "properties": {
         "poetry": {
-          "$ref": "#/definitions/Poetry"
+          "name": "Package",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version", "description"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Package name."
+            },
+            "version": {
+              "type": "string",
+              "description": "Package version.",
+              "pattern": "v?(?:(?:(?:[0-9]+)!)?(?:[0-9]+(?:\\.[0-9]+)*)(?:[-_\\.]?(?:(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?:[0-9]+)?)?(?:(?:-(?:[0-9]+))|(?:[-_\\.]?(?:post|rev|r)[-_\\.]?(?:[0-9]+)?))?(?:[-_\\.]?(?:dev)[-_\\.]?(?:[0-9]+)?)?)(?:\\+(?:[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?"
+            },
+            "description": {
+              "type": "string",
+              "description": "Short package description."
+            },
+            "keywords": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "A tag/keyword that this package relates to."
+              }
+            },
+            "homepage": {
+              "type": "string",
+              "description": "Homepage URL for the project.",
+              "format": "uri"
+            },
+            "repository": {
+              "type": "string",
+              "description": "Repository URL for the project.",
+              "format": "uri"
+            },
+            "documentation": {
+              "type": "string",
+              "description": "Documentation URL for the project.",
+              "format": "uri"
+            },
+            "license": {
+              "type": "string",
+              "description": "License name."
+            },
+            "authors": {
+              "$ref": "#/definitions/poetry-authors"
+            },
+            "maintainers": {
+              "$ref": "#/definitions/poetry-maintainers"
+            },
+            "readme": {
+              "type": "string",
+              "description": "The path to the README file"
+            },
+            "classifiers": {
+              "type": "array",
+              "description": "A list of trove classifers."
+            },
+            "packages": {
+              "type": "array",
+              "description": "A list of packages to include in the final distribution.",
+              "items": {
+                "type": "object",
+                "description": "Information about where the package resides.",
+                "additionalProperties": false,
+                "required": ["include"],
+                "properties": {
+                  "include": {
+                    "type": "string",
+                    "description": "What to include in the package."
+                  },
+                  "from": {
+                    "type": "string",
+                    "description": "Where the source directory of the package resides."
+                  },
+                  "format": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "The format(s) for which the package must be included."
+                  }
+                }
+              }
+            },
+            "include": {
+              "type": "array",
+              "description": "A list of files and folders to include."
+            },
+            "exclude": {
+              "type": "array",
+              "description": "A list of files and folders to exclude."
+            },
+            "dependencies": {
+              "type": "object",
+              "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
+              "required": ["python"],
+              "properties": {
+                "python": {
+                  "type": "string",
+                  "description": "The Python versions the package is compatible with."
+                }
+              },
+              "$ref": "#/definitions/poetry-dependencies",
+              "additionalProperties": false
+            },
+            "dev-dependencies": {
+              "type": "object",
+              "description": "This is a hash of package name (keys) and version constraints (values) that this package requires for developing it (testing tools and such).",
+              "$ref": "#/definitions/poetry-dependencies",
+              "additionalProperties": false
+            },
+            "extras": {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z-_.0-9]+$": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "build": {
+              "type": "string",
+              "description": "The file used to build extensions."
+            },
+            "source": {
+              "type": "array",
+              "description": "A set of additional repositories where packages can be found.",
+              "additionalProperties": {
+                "$ref": "#/definitions/poetry-repository"
+              },
+              "items": {
+                "$ref": "#/definitions/poetry-repository"
+              }
+            },
+            "scripts": {
+              "type": "object",
+              "description": "A hash of scripts to be installed.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "plugins": {
+              "type": "object",
+              "description": "A hash of hashes representing plugins",
+              "patternProperties": {
+                "^[a-zA-Z-_.0-9]+$": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^[a-zA-Z-_.0-9]+$": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "urls": {
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "type": "string",
+                  "description": "The full url of the custom url."
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/taplo-ide/schemas/pyproject.yaml
+++ b/taplo-ide/schemas/pyproject.yaml
@@ -1,379 +1,334 @@
-$schema: http://json-schema.org/draft-07/schema#
+---
+"$schema": http://json-schema.org/draft-07/schema#
 definitions:
-  Poetry:
-    title: Poetry
-    description: |
-      Configuration for [Poetry](https://python-poetry.org/).
-    evenBetterToml:
-      links:
-        key: https://python-poetry.org/docs/pyproject/
+  poetry-authors:
+    type: array
+    description:
+      List of authors that contributed to the package. This is typically
+      the main maintainers, not the full list.
+
+      The pattern matches strings like "Some words <email@example.com>".
+    items:
+      type: string
+      pattern: "^(?:\\S+?\\s)+?\
+        (?:\
+          <(?:\
+            [a-z0-9!#$%&'*+/=?^_`{|}~-]+\
+            (?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*\
+            |
+            \"(?:\
+              [\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]\
+              |\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f]\
+            )*\"\
+          )\
+          @\
+          (?:\
+            (?:\
+              [a-z0-9]\
+              (?:[a-z0-9-]*[a-z0-9])?\
+              \\.\
+            )+\
+            [a-z0-9]\
+            (?:[a-z0-9-]*[a-z0-9])?\
+            |\\[(?:\
+              (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.\
+            ){3}\
+            (?:\
+              25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?\
+              |[a-z0-9-]*[a-z0-9]:\
+              (?:\
+                [\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]\
+                |\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f]\
+              )+\
+            )\\]\
+          )\
+          >\
+        )?$"
+  poetry-maintainers:
+    type: array
+    description:
+      List of maintainers, other than the original author(s), that upkeep
+      the package.
+    items:
+      type: string
+  poetry-dependencies:
+    type: object
+    patternProperties:
+      "^[a-zA-Z-_.0-9]+$":
+        oneOf:
+          - "$ref": "#/definitions/poetry-dependency"
+          - "$ref": "#/definitions/poetry-long-dependency"
+          - "$ref": "#/definitions/poetry-git-dependency"
+          - "$ref": "#/definitions/poetry-file-dependency"
+          - "$ref": "#/definitions/poetry-path-dependency"
+          - "$ref": "#/definitions/poetry-url-dependency"
+          - "$ref": "#/definitions/poetry-multiple-constraints-dependency"
+  poetry-dependency:
+    type: string
+    description: A version constraint.
+    pattern: "v?(?:\
+      (?:\
+        (?:[0-9]+)!\
+      )\
+      ?(?:\
+        [0-9]+(?:\\.[0-9]+)*\
+      )\
+      (?:\
+        [-_\\.]?(?:(a|b|c|rc|alpha|beta|pre|preview))\
+        [-_\\.]?(?:[0-9]+)?\
+      )?\
+      (?:\
+        (?:\
+          -(?:[0-9]+)\
+        )\
+        |(?:\
+          [-_\\.]?(?:post|rev|r)\
+          [-_\\.]?(?:[0-9]+)?\
+        )\
+      )?\
+      (?:\
+        [-_\\.]?(?:dev)\
+        [-_\\.]?(?:[0-9]+)?\
+        )?\
+      )\
+      (?:\
+        \\+\
+        (?:\
+          [a-z0-9]+\
+          (?:[-_\\.][a-z0-9]+)*\
+        )\
+      )?"
+  poetry-long-dependency:
     type: object
     required:
-      - name
       - version
-      - description
-      - authors
+    additionalProperties: false
+    properties:
+      version:
+        "$ref": "#/definitions/poetry-dependency"
+      python:
+        type: string
+        description: The python versions for which the dependency should be installed.
+      platform:
+        type: string
+        description: The platform(s) for which the dependency should be installed.
+      markers:
+        type: string
+        description:
+          The PEP 508 compliant environment markers for which the dependency
+          should be installed.
+      allow-prereleases:
+        type: boolean
+        description: Whether the dependency allows prereleases or not.
+      allows-prereleases:
+        type: boolean
+        description: Whether the dependency allows prereleases or not.
+      optional:
+        type: boolean
+        description: Whether the dependency is optional or not.
+      extras:
+        type: array
+        description: The required extras for this dependency.
+        items:
+          type: string
+      source:
+        type: string
+        description: The exclusive source used to search for this dependency.
+  poetry-git-dependency:
+    type: object
+    required:
+      - git
+    additionalProperties: false
+    properties:
+      git:
+        type: string
+        description: The url of the git repository.
+        format: uri
+      branch:
+        type: string
+        description: The branch to checkout.
+      tag:
+        type: string
+        description: The tag to checkout.
+      rev:
+        type: string
+        description: The revision to checkout.
+      python:
+        type: string
+        description: The python versions for which the dependency should be installed.
+      platform:
+        type: string
+        description: The platform(s) for which the dependency should be installed.
+      markers:
+        type: string
+        description:
+          The PEP 508 compliant environment markers for which the dependency
+          should be installed.
+      allow-prereleases:
+        type: boolean
+        description: Whether the dependency allows prereleases or not.
+      allows-prereleases:
+        type: boolean
+        description: Whether the dependency allows prereleases or not.
+      optional:
+        type: boolean
+        description: Whether the dependency is optional or not.
+      extras:
+        type: array
+        description: The required extras for this dependency.
+        items:
+          type: string
+  poetry-file-dependency:
+    type: object
+    required:
+      - file
+    additionalProperties: false
+    properties:
+      file:
+        type: string
+        description: The path to the file.
+      python:
+        type: string
+        description: The python versions for which the dependency should be installed.
+      platform:
+        type: string
+        description: The platform(s) for which the dependency should be installed.
+      markers:
+        type: string
+        description:
+          The PEP 508 compliant environment markers for which the dependency
+          should be installed.
+      optional:
+        type: boolean
+        description: Whether the dependency is optional or not.
+      extras:
+        type: array
+        description: The required extras for this dependency.
+        items:
+          type: string
+  poetry-path-dependency:
+    type: object
+    required:
+      - path
+    additionalProperties: false
+    properties:
+      path:
+        type: string
+        description: The path to the dependency.
+      python:
+        type: string
+        description: The python versions for which the dependency should be installed.
+      platform:
+        type: string
+        description: The platform(s) for which the dependency should be installed.
+      markers:
+        type: string
+        description:
+          The PEP 508 compliant environment markers for which the dependency
+          should be installed.
+      optional:
+        type: boolean
+        description: Whether the dependency is optional or not.
+      extras:
+        type: array
+        description: The required extras for this dependency.
+        items:
+          type: string
+      develop:
+        type: boolean
+        description: Whether to install the dependency in development mode.
+  poetry-url-dependency:
+    type: object
+    required:
+      - url
+    additionalProperties: false
+    properties:
+      url:
+        type: string
+        description: The url to the file.
+      python:
+        type: string
+        description: The python versions for which the dependency should be installed.
+      platform:
+        type: string
+        description: The platform(s) for which the dependency should be installed.
+      markers:
+        type: string
+        description:
+          The PEP 508 compliant environment markers for which the dependency
+          should be installed.
+      optional:
+        type: boolean
+        description: Whether the dependency is optional or not.
+      extras:
+        type: array
+        description: The required extras for this dependency.
+        items:
+          type: string
+  poetry-multiple-constraints-dependency:
+    type: array
+    minItems: 1
+    items:
+      oneOf:
+        - "$ref": "#/definitions/poetry-dependency"
+        - "$ref": "#/definitions/poetry-long-dependency"
+        - "$ref": "#/definitions/poetry-git-dependency"
+        - "$ref": "#/definitions/poetry-file-dependency"
+        - "$ref": "#/definitions/poetry-path-dependency"
+        - "$ref": "#/definitions/poetry-url-dependency"
+  poetry-scripts:
+    type: object
+    patternProperties:
+      "^[a-zA-Z-_.0-9]+$":
+        oneOf:
+          - "$ref": "#/definitions/poetry-script"
+          - "$ref": "#/definitions/poetry-extra-script"
+  poetry-script:
+    type: string
+    description: A simple script pointing to a callable object.
+  poetry-extra-script:
+    type: object
+    description: A script that should be installed only if extras are activated.
+    additionalProperties: false
+    properties:
+      callable:
+        "$ref": "#/definitions/poetry-script"
+      extras:
+        type: array
+        description: The required extras for this script.
+        items:
+          type: string
+  poetry-repository:
+    type: object
+    additionalProperties: false
     properties:
       name:
         type: string
-        description: |
-          The name of the package.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#name
-      description:
+        description: The name of the repository
+      url:
         type: string
-        description: |
-          A short description of the package.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#description
-      version:
-        type: string
-        description: |
-          The version of the package.
-
-          This should follow [semantic versioning](https://semver.org). However it will not be enforced and you remain free to follow another specification.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#version
-      license:
-        type: string
-        description: |
-          The license of the package.
-
-          The recommended notation for the most common licenses is (alphabetical):
-          - Apache-2.0
-          - BSD-2-Clause
-          - BSD-3-Clause
-          - BSD-4-Clause
-          - GPL-2.0-only
-          - GPL-2.0-or-later
-          - GPL-3.0-only
-          - GPL-3.0-or-later
-          - LGPL-2.1-only
-          - LGPL-2.1-or-later
-          - LGPL-3.0-only
-          - LGPL-3.0-or-later
-          - MIT
-
-          Optional, but it is highly recommended to supply this.
-
-          If your project is proprietary and does not use a specific licence, you can set this value as Proprietary.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#license
-      authors:
-        type: array
-        description: |
-          The authors of the package.
-
-          This is a list of authors and should contain at least one author. Authors must be in the form `name <email>`.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#authors
-        items:
-          type: string
-          pattern: ^.*\s(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])
-      maintainers:
-        type: array
-        description: |
-          The maintainers of the package. 
-
-          This is a list of maintainers and should be distinct from authors. Maintainers may contain an email and be in the form `name <email>`.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#maintainers
-        items:
-          type: string
-          pattern: ^.*\s(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])
-      readme:
-        type: string
-        description: |
-          The readme file of the package.
-          The file could be either `README.rst` or `README.md`.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#readme
-      homepage:
-        type: string
-        description: |
-          An URL to the website of the project.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#homepage
-      repository:
-        type: string
-        description: |
-          An URL to the repository of the project.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#repository
-      documentation:
-        type: string
-        description: |
-          An URL to the documentation of the project.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#documentation
-      keywords:
-        type: array
-        description: |
-          A list of keywords (max: 5) that the package is related to.
-        items:
-          type: string
-        maxItems: 5
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#keywords
-      classifiers:
-        type: array
-        description: |
-          A list of PyPI [trove classifiers](https://pypi.org/classifiers/) that describe the project. 
-
-          ```toml
-          [tool.poetry]
-          # ...
-          classifiers = [
-              "Topic :: Software Development :: Build Tools",
-              "Topic :: Software Development :: Libraries :: Python Modules"
-          ]
-
-          Note that Python classifiers are still automatically added for you and are determined by your `python` requirement.
-
-          The `license` property will also set the License classifier automatically.
-          ```
-        items:
-          type: string
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#classifiers
-      packages:
-        type: array
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#packages
-        description: |
-          A list of packages and modules to include in the final distribution.
-
-          If your project structure differs from the standard one supported by poetry, you can specify the packages you want to include in the final distribution.
-
-          ```toml
-          [tool.poetry]
-          # ...
-          packages = [
-              { include = "my_package" },
-              { include = "extra_package/**/*.py" },
-          ]
-
-          If your package is stored inside a "source" directory, you must specify it:
-
-          ```toml
-          [tool.poetry]
-          # ...
-          packages = [
-              { include = "my_package", from = "lib" },
-          ]
-          ```
-
-          If you want to restrict a package to a specific build format you can specify it by using `format`:
-
-          ```toml
-          [tool.poetry]
-          # ...
-          packages = [
-              { include = "my_package" },
-              { include = "my_other_package", format = "sdist" },
-          ]
-          ```
-
-          Using `packages` disables the package auto-detection feature meaning you have to explicitly specify the "default" package.
-
-          Poetry is clever enough to detect Python subpackages.
-
-          Thus, you only have to specify the directory where your root package resides.
-          ```
-        items:
-          $ref: "#/definitions/Package"
-      include:
-        type: array
-        description: |
-          A list of patterns that will be included in the final package.
-
-          You can explicitly specify to Poetry that a set of globs should be ignored or included for the purposes of packaging.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#include-and-exclude
-        items:
-          type: string
-      exclude:
-        type: array
-        description: |
-          A list of patterns that will excluded from the final package.
-
-          The globs specified in the exclude field identify a set of files that are not included when a package is built.
-
-          If a VCS is being used for a package, the exclude field will be seeded with the VCS’ ignore settings (`.gitignore` for git for example).
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#include-and-exclude
-        items:
-          type: string
-      dependencies:
-        type: object
-        description: The dependencies of the package.
-
-          Poetry is configured to look for dependencies on PyPi by default. Only the name and a version string are required in this case.
-
-        required:
-          - python
-        properties:
-          python:
-            type: string
-            default: "^3"
-            pattern: "^((((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)+)(,\\s*(((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)))*|(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)$"
-        additionalProperties:
-          type: string
-          pattern: "^((((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)+)(,\\s*(((>=|>|<|=|\\^|~)?\\s*[0-9]+(.[0-9]+)?(.[0-9]+)?|([0-9]+|\\*)(.([0-9]+|\\*))?(.([0-9]+|\\*))?)))*|(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)$"
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
-      dev-dependencies:
-        type: object
-        description: The dev-dependencies of the package.
-
-          Poetry is configured to look for dependencies on PyPi by default. Only the name and a version string are required in this case.
-        required:
-          - python
-        properties:
-          python:
-            type: string
-        additionalProperties:
-          type: string
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
-      source:
-        type: array
-        description: |
-          Additional sources of dependencies.
-        items:
-          type: object
-          description: A dependency source.
-          required:
-            - name
-            - url
-          properties:
-            name:
-              type: string
-              description: The name of the source.
-            url:
-              type: string
-              description: The source URL.
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
-      scripts:
-        type: object
+        description: The url of the repository
+        format: uri
+      default:
+        type: boolean
+        description: Make this repository the default (disable PyPI)
+      secondary:
+        type: boolean
         description:
-          Scripts or executable that will be installed when installing the package.
-
-          ```toml
-          [tool.poetry.scripts]
-          poetry = 'poetry.console:run'
-          ```
-
-          Here, we will have the poetry script installed which will execute `console.run` in the `poetry` package.
-        additionalProperties:
-          type: string
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#scripts
-      extras:
-        type: object
-        description: |
-          Poetry supports extras to allow expression of:
-          - optional dependencies, which enhance a package, but are not required; and
-          - clusters of optional dependencies.
-
-          ```toml          
-          [tool.poetry]
-          name = "awesome"
-
-          [tool.poetry.dependencies]
-          # These packages are mandatory and form the core of this package’s distribution.
-          mandatory = "^1.0"
-
-          # A list of all of the optional dependencies, some of which are included in the
-          # below `extras`. They can be opted into by apps.
-          psycopg2 = { version = "^2.7", optional = true }
-          mysqlclient = { version = "^1.3", optional = true }
-
-          [tool.poetry.extras]
-          mysql = ["mysqlclient"]
-          pgsql = ["psycopg2"]
-          ```
-
-          When installing packages, you can specify extras by using the `-E|--extras` option:
-          ```
-          poetry install --extras "mysql pgsql"
-          poetry install -E mysql -E pgsql
-          ```
-        additionalProperties:
-          type: array
-          items:
-            type: string
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#extras
-      plugins:
-        type: object
-        description: |
-          Poetry supports arbitrary plugins which work similarly to setuptools entry points. To match the example in the setuptools documentation, you would use the following:
-          ```toml
-          [tool.poetry.plugins] # Optional super table
-
-          [tool.poetry.plugins."blogtool.parsers"]
-          ".rst" = "some_module:SomeClass"          
-          ```
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#plugins
-        additionalProperties:
-          type: object
-          additionalProperties:
-            type: string
-      urls:
-        type: object
-        description: |
-          In addition to the basic urls (homepage, repository and documentation), you can specify any custom url in the urls section.
-
-          ```toml
-          [tool.poetry.urls]
-          "Bug Tracker" = "https://github.com/python-poetry/poetry/issues"
-          ```
-
-          If you publish you package on PyPI, they will appear in the `Project Links` section.
-        additionalProperties:
-          type: string
-
-        evenBetterToml:
-          links:
-            key: https://python-poetry.org/docs/pyproject/#urls
+          Declare this repository as secondary, i.e. it will only be looked
+          up last for packages.
   BuildSystem:
     title: Build System
     type: object
     evenBetterToml:
       links:
         key: https://www.python.org/dev/peps/pep-0518/#build-system-table
-    description: |
-      Build-related data.
+    description: Build-related data.
     required:
       - requires
     properties:
       requires:
-        description: |
-          A list of strings representing [PEP 508](https://www.python.org/dev/peps/pep-0508) dependencies required to execute the build system.
+        description: A list of strings representing [PEP 508](https://www.python.org/dev/peps/pep-0508) dependencies required to execute the build system.
         type: array
         items:
           type: string
@@ -381,48 +336,155 @@ definitions:
           links:
             key: https://www.python.org/dev/peps/pep-0518/#build-system-table
       build-backend:
-        description: |
-          The build backend for the package.
+        description: The build backend for the package.
         type: string
         evenBetterToml:
           links:
             key: https://www.python.org/dev/peps/pep-0517/
-  Package:
-    title: Package
-    type: object
-    description: |
-      A package to include with Poetry.
-    required:
-      - include
-    properties:
-      include:
-        description: |
-          A package name or glob pattern to the package.
-        type: string
-      from:
-        description: |
-          The directory of the package.
-        type: string
-      format:
-        description: |
-          Build format for the package.
-        type: string
 type: object
 properties:
   build-system:
-    $ref: "#/definitions/BuildSystem"
+    "$ref": "#/definitions/BuildSystem"
   tool:
     type: object
-    description: |
-      A table for tool configurations.
-
-      Every tool that is used by the project can have its own sub-table for its configuration.
+    description: A table for tool configurations. Every tool that is used by the project can have its own sub-table for its configuration.
     additionalProperties: true
     evenBetterToml:
       links:
         key: https://www.python.org/dev/peps/pep-0518/#id28
     properties:
       poetry:
-        $ref: "#/definitions/Poetry"
-
+        name: Package
+        type: object
+        additionalProperties: false
+        required:
+          - name
+          - version
+          - description
+        properties:
+          name:
+            type: string
+            description: Package name.
+          version:
+            "$ref": "#/definitions/poetry-dependency"
+          description:
+            type: string
+            description: Short package description.
+          keywords:
+            type: array
+            items:
+              type: string
+              description: A tag/keyword that this package relates to.
+          homepage:
+            type: string
+            description: Homepage URL for the project.
+            format: uri
+          repository:
+            type: string
+            description: Repository URL for the project.
+            format: uri
+          documentation:
+            type: string
+            description: Documentation URL for the project.
+            format: uri
+          license:
+            type: string
+            description: License name.
+          authors:
+            "$ref": "#/definitions/poetry-authors"
+          maintainers:
+            "$ref": "#/definitions/poetry-maintainers"
+          readme:
+            type: string
+            description: The path to the README file
+          classifiers:
+            type: array
+            description: A list of trove classifers.
+          packages:
+            type: array
+            description: A list of packages to include in the final distribution.
+            items:
+              type: object
+              description: Information about where the package resides.
+              additionalProperties: false
+              required:
+                - include
+              properties:
+                include:
+                  type: string
+                  description: What to include in the package.
+                from:
+                  type: string
+                  description: Where the source directory of the package resides.
+                format:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                  description: The format(s) for which the package must be included.
+          include:
+            type: array
+            description: A list of files and folders to include.
+          exclude:
+            type: array
+            description: A list of files and folders to exclude.
+          dependencies:
+            type: object
+            description:
+              This is a hash of package name (keys) and version constraints
+              (values) that are required to run this package.
+            required:
+              - python
+            properties:
+              python:
+                type: string
+                description: The Python versions the package is compatible with.
+            "$ref": "#/definitions/poetry-dependencies"
+            additionalProperties: false
+          dev-dependencies:
+            type: object
+            description:
+              This is a hash of package name (keys) and version constraints
+              (values) that this package requires for developing it (testing tools
+              and such).
+            "$ref": "#/definitions/poetry-dependencies"
+            additionalProperties: false
+          extras:
+            type: object
+            patternProperties:
+              "^[a-zA-Z-_.0-9]+$":
+                type: array
+                items:
+                  type: string
+          build:
+            type: string
+            description: The file used to build extensions.
+          source:
+            type: array
+            description: A set of additional repositories where packages can be found.
+            additionalProperties:
+              "$ref": "#/definitions/poetry-repository"
+            items:
+              "$ref": "#/definitions/poetry-repository"
+          scripts:
+            type: object
+            description: A hash of scripts to be installed.
+            items:
+              type: string
+          plugins:
+            type: object
+            description: A hash of hashes representing plugins
+            patternProperties:
+              "^[a-zA-Z-_.0-9]+$":
+                type: object
+                patternProperties:
+                  "^[a-zA-Z-_.0-9]+$":
+                    type: string
+          urls:
+            type: object
+            patternProperties:
+              "^.+$":
+                type: string
+                description: The full url of the custom url.
 additionalProperties: true


### PR DESCRIPTION
Updates the bundled `pyproject.json` jsonschema that the extension uses to validate `pyproject.toml`.

Resolves #35, #34

Following from #2, Remote schema `$ref`s would be a great feature to remove having to update schemas in places like this. I'm not convinced that poetry's schema **isn't** going to change in the next long while. 