### PR TITLE
Bump lsp-types version to match tower-lsp

### DIFF
--- a/taplo/Cargo.toml
+++ b/taplo/Cargo.toml
@@ -23,7 +23,7 @@ rewrite = []
 glob = "0.3"
 indexmap = "1"
 logos = "0.11.4"
-lsp-types = { version = "0.74.1" }
+lsp-types = ">=0.79, <0.82"
 regex = "1"
 rowan = "0.10.0"
 smallvec = "1"


### PR DESCRIPTION
Good afternoon, we would like to use taplo and some components from taplo's LSP to provide autocompletion for toml configuration in our linter's LSP. However, taplo uses a relatively old version of lsp-types which is incompatible with tower-lsp. This PR bumps the version of lsp-types to match tower-lsp