### PR TITLE
Add builtin rustfmt schema

### DIFF
--- a/taplo/CHANGELOG.md
+++ b/taplo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Additions
+- Builtin `rustfmt.toml` schema added
+
 ## 0.4.0
 
 ### Breaking Changes

--- a/taplo/schemas/rustfmt.json
+++ b/taplo/schemas/rustfmt.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "rustfmt schema",
+  "type": "object",
+  "description": "https://rust-lang.github.io/rustfmt",
+  "properties": {
+    "tab_spaces": {
+      "type": "integer",
+      "description": "Number of spaces per tab",
+      "default": 4
+    },
+    "fn_args_layout": {
+      "type": "string",
+      "description": "Control the layout of arguments in a function",
+      "default": "Tall",
+      "enum": [
+        "Compressed",
+        "Tall",
+        "Vertical"
+      ]
+    },
+    "merge_derives": {
+      "type": "boolean",
+      "description": "Merge multiple `#[derive(...)]` into a single one",
+      "default": true,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "print_misformatted_file_names": {
+      "type": "boolean",
+      "description": "Prints the names of mismatched files that were formatted. Prints the names of files that would be formated when used with `--check` mode.",
+      "default": false,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "remove_nested_parens": {
+      "type": "boolean",
+      "description": "Remove nested parens",
+      "default": true,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "use_small_heuristics": {
+      "type": "string",
+      "description": "Whether to use different formatting for items and expressions if they satisfy a heuristic notion of 'small'",
+      "default": "Default",
+      "enum": [
+        "Off",
+        "Max",
+        "Default"
+      ]
+    },
+    "use_try_shorthand": {
+      "type": "boolean",
+      "description": "Replace uses of the try! macro by the ? shorthand",
+      "default": false,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "reorder_modules": {
+      "type": "boolean",
+      "description": "Reorder module statements alphabetically in group",
+      "default": true,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "hard_tabs": {
+      "type": "boolean",
+      "description": "Use tab characters for indentation, spaces for alignment",
+      "default": false,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "use_field_init_shorthand": {
+      "type": "boolean",
+      "description": "Use field initialization shorthand if possible",
+      "default": false,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "max_width": {
+      "type": "integer",
+      "description": "Maximum width of each line",
+      "default": 100
+    },
+    "reorder_imports": {
+      "type": "boolean",
+      "description": "Reorder import and extern crate statements alphabetically",
+      "default": true,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "match_arm_leading_pipes": {
+      "type": "string",
+      "description": "Determines whether leading pipes are emitted on match arms",
+      "default": "Never",
+      "enum": [
+        "Always",
+        "Never",
+        "Preserve"
+      ]
+    },
+    "force_explicit_abi": {
+      "type": "boolean",
+      "description": "Always print the abi for extern items",
+      "default": true,
+      "enum": [
+        true,
+        false
+      ]
+    },
+    "edition": {
+      "type": "string",
+      "description": "The edition of the parser (RFC 2052)",
+      "default": "2015",
+      "enum": [
+        "2015",
+        "2018"
+      ]
+    },
+    "newline_style": {
+      "type": "string",
+      "description": "Unix or Windows line endings",
+      "default": "Auto",
+      "enum": [
+        "Auto",
+        "Windows",
+        "Unix",
+        "Native"
+      ]
+    }
+  }
+}

--- a/taplo/src/schema.rs
+++ b/taplo/src/schema.rs
@@ -10,7 +10,7 @@ pub const BUILTIN_SCHEME: &str = "taplo";
 
 pub static BUILTIN_SCHEMAS: Lazy<HashMap<String, RootSchema>> = Lazy::new(|| {
     let mut schemas = HashMap::new();
-    
+
     schemas.insert(
         format!("{}://cargo@Cargo.toml", BUILTIN_SCHEME),
         serde_json::from_str(include_str!("../schemas/Cargo.json")).unwrap(),
@@ -18,6 +18,10 @@ pub static BUILTIN_SCHEMAS: Lazy<HashMap<String, RootSchema>> = Lazy::new(|| {
     schemas.insert(
         format!("{}://python@pyproject.toml", BUILTIN_SCHEME),
         serde_json::from_str(include_str!("../schemas/pyproject.json")).unwrap(),
+    );
+    schemas.insert(
+        format!("{}://rustfmt@rustfmt.toml", BUILTIN_SCHEME),
+        serde_json::from_str(include_str!("../schemas/rustfmt.json")).unwrap(),
     );
     schemas.insert(
         format!("{}://taplo@taplo.toml", BUILTIN_SCHEME),
@@ -32,9 +36,10 @@ pub static BUILTIN_SCHEMAS: Lazy<HashMap<String, RootSchema>> = Lazy::new(|| {
 
 pub static REGEX_ASSOCIATIONS: Lazy<HashMap<String, String>> = Lazy::new(|| {
     let mut associations = HashMap::new();
-   
+
     associations.insert(".*/Cargo\\.toml".to_string(), "taplo://cargo@Cargo.toml".to_string());
     associations.insert(".*/pyproject\\.toml".to_string(), "taplo://python@pyproject.toml".to_string());
+    associations.insert(".*/\\.?rustfmt\\.toml".to_string(), "taplo://rustfmt@rustfmt.toml".to_string());
     associations.insert(".*/\\.?taplo\\.toml".to_string(), "taplo://taplo@taplo.toml".to_string());
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
This adds a schema for `rustfmt.toml` and `.rustfmt.toml` files.

The schema is auto-generated with a script I wrote: https://github.com/Aloso/rustfmt-schema-maker

I hope the code is okay, because I was too lazy to locally build the extension 😝