### PR TITLE
Update assert-json-diff to 2.0

### DIFF
--- a/taplo/Cargo.toml
+++ b/taplo/Cargo.toml
@@ -42,7 +42,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 toml = "0.5"
 
 [dev-dependencies]
-assert-json-diff = "1"
+assert-json-diff = "2"
 serde_json = "1"
 toml = "0.5"
 


### PR DESCRIPTION
Hey 👋 

I recently released assert-json-diff 2.0.0 which had [a few breaking changes](https://github.com/davidpdrsn/assert-json-diff/blob/main/CHANGELOG.md#200---2021-01-23).