### PR TITLE
Formatter Rework

### DIFF
--- a/taplo/Cargo.toml
+++ b/taplo/Cargo.toml
@@ -22,10 +22,10 @@ rewrite = []
 [dependencies]
 glob = "0.3"
 indexmap = "1"
-logos = "0.11.4"
+logos = "0.12.0"
 regex = "1"
-rowan = "0.10.0"
-semver = { version = "0.11", features = ["serde"] }
+rowan = "0.12.6"
+semver = { version = "1.0.3", features = ["serde"] }
 smallvec = "1"
 
 chrono = { version = "0.4", optional = true }

--- a/taplo/Cargo.toml
+++ b/taplo/Cargo.toml
@@ -21,18 +21,18 @@ rewrite = []
 
 [dependencies]
 glob = "0.3"
-indexmap = "1"
+indexmap = "1.6.2"
 logos = "0.12.0"
-regex = "1"
+regex = "1.5.4"
 rowan = "0.12.6"
 semver = { version = "1.0.3", features = ["serde"] }
-smallvec = "1"
+smallvec = "1.6.1"
 
 chrono = { version = "0.4", optional = true }
 time = { version = "0.2", optional = true }
 
-once_cell = { version = "1", optional = true }
-schemars = { version = "0.8", optional = true }
+once_cell = { version = "1.8.0", optional = true }
+schemars = { version = "0.8.3", optional = true }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 verify = { version = "0.3", features = ["schemars", "serde"], optional = true }
@@ -45,6 +45,7 @@ toml = "0.5"
 assert-json-diff = "2"
 serde_json = "1"
 toml = "0.5"
+difference = "2.0.0"
 
 [package.metadata.docs.rs]
 features = ["serde", "schema", "chrono", "rewrite"]

--- a/taplo/src/dom/mod.rs
+++ b/taplo/src/dom/mod.rs
@@ -1179,7 +1179,7 @@ impl KeyNode {
     }
 
     pub fn keys_str(&self) -> impl Iterator<Item = &str> {
-        self.idents().map(|t| t.text().as_str())
+        self.idents().map(|t| t.text())
     }
 
     /// Quotes are removed from the keys.
@@ -1582,7 +1582,6 @@ impl Cast for StringNode {
                         .as_token()
                         .unwrap()
                         .text()
-                        .as_str()
                         .strip_prefix(r#"""#)
                         .unwrap()
                         .strip_suffix(r#"""#)
@@ -1600,7 +1599,6 @@ impl Cast for StringNode {
                         .as_token()
                         .unwrap()
                         .text()
-                        .as_str()
                         .strip_prefix(r#"""""#)
                         .unwrap()
                         .strip_suffix(r#"""""#)
@@ -1623,7 +1621,6 @@ impl Cast for StringNode {
                     .as_token()
                     .unwrap()
                     .text()
-                    .as_str()
                     .strip_prefix(r#"'"#)
                     .unwrap()
                     .strip_suffix(r#"'"#)
@@ -1638,7 +1635,6 @@ impl Cast for StringNode {
                         .as_token()
                         .unwrap()
                         .text()
-                        .as_str()
                         .strip_prefix(r#"'''"#)
                         .unwrap()
                         .strip_suffix(r#"'''"#)

--- a/taplo/src/parser/mod.rs
+++ b/taplo/src/parser/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use dom::Cast;
 use logos::{Lexer, Logos};
-use rowan::{GreenNode, GreenNodeBuilder, SmolStr, TextRange, TextSize};
+use rowan::{GreenNode, GreenNodeBuilder, TextRange, TextSize};
 use std::convert::TryInto;
 
 #[macro_use]
@@ -157,7 +157,7 @@ impl<'p> Parser<'p> {
         self.error_whitelist & token as u16 != 0
     }
 
-    fn insert_token(&mut self, kind: SyntaxKind, s: SmolStr) {
+    fn insert_token(&mut self, kind: SyntaxKind, s: &str) {
         self.builder.token(kind.into(), s)
     }
 

--- a/taplo/src/tests/formatter.rs
+++ b/taplo/src/tests/formatter.rs
@@ -596,3 +596,95 @@ inline_table={ key="value" }
 
     assert_format!(expected, &formatted);
 }
+
+#[test]
+fn array_no_trailing_comma() {
+    let src = r#"
+my_array = [
+    [
+        [
+            [
+                "my_value",
+            ]
+        ]
+    ]
+]
+"#;
+
+let expected = r#"
+my_array = [
+    [
+        [
+            [
+                "my_value"
+            ]
+        ]
+    ]
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: false,
+            array_trailing_comma: false,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+
+#[test]
+fn array_max_new_lines() {
+    let src = r#"
+my_array = [
+    [
+        [
+            [
+                "my_value"
+
+
+
+
+
+
+
+
+
+
+
+            ]
+        ]
+    ]
+]
+"#;
+
+let expected = r#"
+my_array = [
+    [
+        [
+            [
+                "my_value"
+
+
+            ]
+        ]
+    ]
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: false,
+            array_trailing_comma: false,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}

--- a/taplo/src/tests/formatter.rs
+++ b/taplo/src/tests/formatter.rs
@@ -306,3 +306,293 @@ a            = "longer_string_hm" # trailing comment
 
     assert_format!(expected, &formatted);
 }
+
+#[test]
+fn test_nested_arrays() {
+    let src = r#"
+my_array = [
+    [
+        "my_value",
+    ]
+]
+"#;
+
+    let expected = r#"
+my_array = [
+    [
+        "my_value",
+    ],
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: false,
+            align_entries: true,
+            array_auto_collapse: false,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_too_long_array() {
+    let src = r#"
+array_is_just_right = ["this_line_is_exactly_80_characters_long", "filler_data"]
+"#;
+
+    let expected = r#"
+array_is_just_right = ["this_line_is_exactly_80_characters_long", "filler_data"]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: false,
+            array_auto_expand: true,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+
+    let src = r#"
+array_is_a_bit_too_long = ["this_line_is_exactly_80_characters_long", "filler_data"]
+"#;
+
+    let expected = r#"
+array_is_a_bit_too_long = [
+    "this_line_is_exactly_80_characters_long",
+    "filler_data",
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: false,
+            array_auto_expand: true,
+            column_width: 80,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_cargo_toml() {
+    let src = r#"
+[package]
+authors = ["tamasfe"]
+categories = ["parser-implementations", "parsing"]
+description = "A TOML parser, analyzer and formatter library"
+edition = "2018"
+homepage = "https://taplo.tamasfe.dev"
+keywords = ["toml", "parser", "formatter", "linter"]
+license = "MIT"
+name = "taplo"
+readme = "../README.md"
+repository = "https://github.com/tamasfe/taplo"
+version = "0.5.4"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+serde = ["serde_crate", "serde_json"]
+schema = ["once_cell", "schemars", "serde"]
+rewrite = []
+
+[dependencies]
+glob = "0.3"
+indexmap = "1.6.2"
+logos = "0.12.0"
+regex = "1.5.4"
+rowan = "0.12.6"
+semver = { version = "1.0.3", features = ["serde"] }
+smallvec = "1.6.1"
+
+chrono = { version = "0.4", optional = true }
+time = { version = "0.2", optional = true }
+
+once_cell = { version = "1.8.0", optional = true }
+schemars = { version = "0.8.3", optional = true }
+serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+verify = { version = "0.3", features = ["schemars", "serde"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+toml = "0.5"
+
+[dev-dependencies]
+assert-json-diff = "2"
+serde_json = "1"
+toml = "0.5"
+difference = "2.0.0"
+
+[package.metadata.docs.rs]
+features = ["serde", "schema", "chrono", "rewrite"]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: false,
+            array_auto_expand: true,
+            column_width: 90,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(src, &formatted);
+}
+
+#[test]
+fn test_very_nested_arrays() {
+    let src = r#"
+my_array = [
+    [
+        [
+            [
+                "my_value",
+            ],
+        ],
+    ],
+    [
+        [
+            [
+                "my_value",
+            ],
+        ],
+    ],
+    [
+        [
+            [
+                [{ even = { more = ["nested"] } }],
+            ],
+        ],
+    ],
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: false,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(src, &formatted);
+}
+
+#[test]
+fn array_collapse() {
+    let src = r#"
+my_array = [
+    [
+        [
+            [
+                "my_value",
+            ],
+        ],
+    ],
+]
+"#;
+
+    let expected = r#"
+my_array = [[[["my_value"]]]]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: true,
+            compact_arrays: true,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn trailing_newline() {
+    let src = r#"trailing_new_line = {}"#;
+
+    let expected = r#"trailing_new_line = {}
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: true,
+            compact_arrays: true,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn no_trailing_newline() {
+    let src = r#"no_new_line = {}
+"#;
+
+    let expected = r#"no_new_line = {}"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: true,
+            compact_arrays: true,
+            trailing_newline: false,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_compact_entries() {
+    let src = r#"
+entry1asdasd =  "string"     # trailing comment
+entry2asd   = "longer_string"        # trailing comment
+a         = "longer_string_hm" # trailing comment
+inline_table = { key = "value" }
+"#;
+
+    let expected = r#"
+entry1asdasd="string"        # trailing comment
+entry2asd="longer_string"    # trailing comment
+a="longer_string_hm"         # trailing comment
+inline_table={ key="value" }
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: true,
+            align_entries: false,
+            compact_entries: true,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}

--- a/taplo/src/tests/formatter.rs
+++ b/taplo/src/tests/formatter.rs
@@ -1,4 +1,15 @@
+use difference::Changeset;
+
 use crate::formatter;
+
+macro_rules! assert_format {
+    ($expected:expr, $actual:expr) => {
+        if $expected != $actual {
+            println!("{}", Changeset::new($actual, $expected, "\n"));
+            panic!("invalid formatting");
+        }
+    };
+}
 
 #[test]
 fn comment_indentation() {
@@ -12,12 +23,14 @@ fn comment_indentation() {
 
 # bsd 
  # bsd
+asd = ""
 
 # csd
     [profile.release]
 
-    incremental = true 
-    debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
+    incremental  = true 
+    lol = 2 #yo
+    debug = 0          # Set this to 1 or 2 to get more useful backtraces in debugger.
 
     # asd"#,
         formatter::Options {
@@ -35,32 +48,35 @@ fn comment_indentation() {
 
 # bsd 
 # bsd
+asd = ""
 
   # csd
   [profile.release]
 
   incremental = true
-  debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
+  lol = 2            #yo
+  debug = 0          # Set this to 1 or 2 to get more useful backtraces in debugger.
 
   # asd
 "#;
-    assert_eq!(formatted, expected);
+    assert_format!(expected, &formatted);
 }
 
 #[test]
 fn comment_after_entry() {
-    let src = r#"incremental = true
+    let expected = r#"incremental = true
+
 debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 "#;
 
-    let formatted = crate::formatter::format(src, formatter::Options::default());
+    let formatted = crate::formatter::format(expected, formatter::Options::default());
 
-    assert_eq!(src, formatted);
+    assert_format!(expected, &formatted);
 }
 
 #[test]
 fn comment_before_entry() {
-    let src = r#"
+    let expected = r#"
 
 # hello
 [lib]
@@ -68,14 +84,12 @@ fn comment_before_entry() {
 incremental = true
 "#;
 
-    let formatted = crate::formatter::format(src, formatter::Options::default());
+    let formatted = crate::formatter::format(expected, formatter::Options::default());
 
-    assert_eq!(src, formatted);
+    assert_format!(expected, &formatted);
 }
 
-// TODO: handle alignment better
 #[test]
-#[ignore]
 fn align_composite_entries() {
     let src = r#"k1 = 1                                                      # 111
 k2 = false                                                  # 222
@@ -93,16 +107,15 @@ k5 = false                                                  # 555
         },
     );
 
-    assert_eq!(
-        r#"k1 = 1                             # 111
+    let expected = r#"k1 = 1                             # 111
 k2 = false                         # 222
 k3 = "public"                      # 333
 k4 = ["/home/www", "/var/lib/www"] # 4444444444444444444444
 k6 = { a = "yes", table = "yes" }  # 4444444444444444444444
 k5 = false                         # 555
-"#,
-        formatted
-    );
+"#;
+
+    assert_format!(expected, &formatted);
 }
 
 #[test]
@@ -130,8 +143,7 @@ foo = "bar"
         },
     );
 
-    assert_eq!(
-        r#"
+    let expected = r#"
 [foo]
 
 foo = "bar"
@@ -141,14 +153,14 @@ bar = "foo"
 
 [bar]
 foo = "bar"
-"#,
-        formatted
-    );
+"#;
+
+    assert_format!(expected, &formatted);
 }
 
 #[test]
 fn test_comment_in_array() {
-    let src = r#"
+    let expected = r#"
 [features]
 myfeature = [
   "feature1",
@@ -158,19 +170,19 @@ myfeature = [
 nextfeature = []
 "#;
     let formatted = crate::formatter::format(
-        src,
+        expected,
         formatter::Options {
             align_entries: false,
             ..Default::default()
         },
     );
 
-    assert_eq!(src, &formatted);
+    assert_format!(expected, &formatted);
 }
 
 #[test]
 fn test_comments_in_array() {
-    let src = r#"
+    let expected = r#"
 [main]
 my_array = [
   #Items
@@ -193,11 +205,104 @@ my_array = [
 "#;
 
     let formatted = crate::formatter::format(
-        src,
+        expected,
         formatter::Options {
             ..Default::default()
         },
     );
 
-    assert_eq!(src, &formatted);
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_align_comments() {
+    let src = r#"
+entry1 = "string"  # trailing comment
+entry2 = "longer_string"  # trailing comment
+
+my_array = [
+  #Items
+  "abc",  # comment
+  "b", # Some comment
+  "caa",    # This is special
+ # comment
+  # Other stuff
+]
+"#;
+
+    let expected = r#"
+entry1 = "string"        # trailing comment
+entry2 = "longer_string" # trailing comment
+
+my_array = [
+  #Items
+  "abc", # comment
+  "b",   # Some comment
+  "caa", # This is special
+  # comment
+  # Other stuff
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: true,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_more_comment_alignments() {
+    let src = r#"
+entry1asdasd = "string"     # trailing comment
+entry2asd = "longer_string" # trailing comment
+a = "longer_string_hm"      # trailing comment
+"#;
+
+    let expected = r#"
+entry1asdasd = "string"     # trailing comment
+entry2asd = "longer_string" # trailing comment
+a = "longer_string_hm"      # trailing comment
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: true,
+            align_entries: false,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_align_entries_no_comments() {
+    let src = r#"
+entry1asdasd =  "string"     # trailing comment
+entry2asd   = "longer_string"        # trailing comment
+a         = "longer_string_hm" # trailing comment
+"#;
+
+    let expected = r#"
+entry1asdasd = "string" # trailing comment
+entry2asd    = "longer_string" # trailing comment
+a            = "longer_string_hm" # trailing comment
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: false,
+            align_entries: true,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
 }


### PR DESCRIPTION
PR for #123.

Notable changes include:

- we work with strings only (also removed SmolStr)
- better handling of comments with a generic trait
- simplified code where possible

TODO:
- [x] array formatting
- [x] generic `tabwriter` for vertical alignments (e.g. comments after values in multi-line arrays)
- [x] tests
- [x] <s>document new features</s> this shouldn't block this PR
- [x] reorganize, split code to multiple files if needed
