### PR TITLE
Move wasm-bindgen usage to a cargo feature to support building for Wasm without defining exports

### DIFF
--- a/taplo/Cargo.toml
+++ b/taplo/Cargo.toml
@@ -15,9 +15,11 @@ version = "0.5.4"
 crate-type = ["cdylib", "lib"]
 
 [features]
+default = ["wasm_bindgen"]
 serde = ["serde_crate", "serde_json"]
 schema = ["once_cell", "schemars", "serde"]
 rewrite = []
+wasm_bindgen = ["wasm-bindgen", "toml"]
 
 [dependencies]
 glob = "0.3"
@@ -38,8 +40,8 @@ serde_json = { version = "1", optional = true }
 verify = { version = "0.3", features = ["schemars", "serde"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
-toml = "0.5"
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
+toml = { version = "0.5", optional = true }
 
 [dev-dependencies]
 assert-json-diff = "2"

--- a/taplo/src/lib.rs
+++ b/taplo/src/lib.rs
@@ -87,7 +87,7 @@ pub use rowan;
 #[cfg(test)]
 mod tests;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm_bindgen"))]
 pub mod wasm;
 
 #[cfg(all(feature = "chrono", feature = "time"))]


### PR DESCRIPTION
Hello! Thanks for this crate! I've been investigating a bunch of TOML parsers and found yours to be the best out of all the ones I tried. I'd like to use the parser in a Wasm build, but right now the crate adds wasm-bindgen exports, which isn't desirable when it's used internally by some other Wasm code.

After this change, the code should work the same as it currently does. I think though that eventually it should be flipped so that using wasm-bindgen is opt-in rather than opt-out.

Thanks! (Also, I've used the parser to create a code formatter... I understand that taplo has a built-in code formatter, but toml is such a simple language and I prefer full control over the output)