### PR TITLE
fix unneeded content-length adjustment

### DIFF
--- a/taplo-lsp/bin/lsp/stdio.rs
+++ b/taplo-lsp/bin/lsp/stdio.rs
@@ -150,7 +150,7 @@ fn read_message<R: std::io::BufRead>(mut input: R) -> Result<Option<rpc::Message
         };
         if header_name == "Content-Length" {
             size = match header_value.parse::<usize>() {
-                Ok(s) => s + 2, // For "\r\n" at the end
+                Ok(s) => s,
                 Err(err) => {
                     return Err(anyhow!("invalid content-length: {}", err));
                 }

--- a/taplo-lsp/bin/lsp/tcp.rs
+++ b/taplo-lsp/bin/lsp/tcp.rs
@@ -208,7 +208,7 @@ async fn read_message<R: AsyncBufRead + Unpin>(
         };
         if header_name == "Content-Length" {
             size = match header_value.parse::<usize>() {
-                Ok(s) => s + 2, // For "\r\n" at the end
+                Ok(s) => s,
                 Err(err) => {
                     return Err(anyhow!("invalid content-length: {}", err));
                 }


### PR DESCRIPTION
fixes #162

I think that the vscode extension uses wasm binding, so it should not be affected by this fix.