### PR TITLE
docs(site): fix keys value syntax to array in config file

### DIFF
--- a/site/src/pages/configuration.mdx
+++ b/site/src/pages/configuration.mdx
@@ -129,7 +129,7 @@ reorder_keys = false
 
 [[rule]]
 include = ["**/Cargo.toml"]
-keys = "dependencies"
+keys = ["dependencies"]
 
 [rule.formatting]
 reorder_keys = true


### PR DESCRIPTION
If I need to create an issue to fix the document, I am sorry.

After reading [CONTRIBUTING.md](https://github.com/tamasfe/taplo/blob/master/CONTRIBUTING.md), I don't think I need to create an issue to fix the document. So, I did not create the issue.

---

If it is `keys = "dependencies"` as in the following, an error will occur, so I fixed it to `keys = ["dependencies"]`.

```toml
[formatting]
reorder_keys = false

[[rule]]
include = ["**/Cargo.toml"]
keys = "dependencies"

[rule.formatting]
reorder_keys = true
```

```shell
> taplo format
error: failed to read configuration: invalid type: string "dependencies", expected a sequence for key `rule.keys` at line 6 column 8
```