### PR TITLE
Avoid panic if request position is out of mapper's range

### DIFF
--- a/taplo-lsp/Cargo.toml
+++ b/taplo-lsp/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.5"
 hex = "0.4"
 indexmap = "1.6"
 itertools = "0.10.1"
-lsp-async-stub = { version = "0.2.0", path = "../lsp-async-stub" }
+lsp-async-stub = { version = "0.3.0", path = "../lsp-async-stub" }
 lsp-types = { version = "0.90.0", features = ["proposed"] }
 once_cell = "1.5"
 pathdiff = "0.2"

--- a/taplo-lsp/src/handlers.rs
+++ b/taplo-lsp/src/handlers.rs
@@ -566,9 +566,17 @@ pub(crate) async fn completion(
         }
     };
 
+    let offset = match doc
+        .mapper
+        .offset(taplo::util::coords::Position::from_lsp(pos))
+    {
+        Some(x) => x,
+        None => return Ok(None),
+    };
+
     Ok(Some(CompletionResponse::List(CompletionList {
         is_incomplete: false,
-        items: completion::get_completions(doc, pos, schema),
+        items: completion::get_completions(doc, offset, schema),
     })))
 }
 
@@ -612,11 +620,14 @@ pub(crate) async fn hover(
 
     let dom = doc.parse.clone().into_dom();
 
-    let query = dom.query_position(
-        doc.mapper
-            .offset(taplo::util::coords::Position::from_lsp(pos))
-            .unwrap(),
-    );
+    let offset = match doc
+        .mapper
+        .offset(taplo::util::coords::Position::from_lsp(pos))
+    {
+        Some(x) => x,
+        None => return Ok(None),
+    };
+    let query = dom.query_position(offset);
 
     let schemas = get_schema_objects(query.after.path, &schema, true);
     let syntax_range = query.after.syntax.range;

--- a/taplo-lsp/src/handlers/code_action.rs
+++ b/taplo-lsp/src/handlers/code_action.rs
@@ -34,10 +34,13 @@ pub(crate) async fn code_action(
         return Ok(Some(Vec::new()));
     }
 
-    let range = doc
+    let range = match doc
         .mapper
         .text_range(taplo::util::coords::Range::from_lsp(p.range))
-        .unwrap();
+    {
+        Some(x) => x,
+        None => return Ok(None),
+    };
 
     let dom = doc.parse.into_dom();
 

--- a/taplo-lsp/src/handlers/completion.rs
+++ b/taplo-lsp/src/handlers/completion.rs
@@ -1,6 +1,7 @@
 use crate::{utils::LspExt, Document};
 use itertools::Itertools;
 use lsp_types::*;
+use rowan::TextSize;
 use schemars::{
     schema::{InstanceType, RootSchema, Schema, SingleOrVec},
     Map,
@@ -16,17 +17,11 @@ use taplo::{
 
 pub(crate) fn get_completions(
     doc: Document,
-    position: Position,
+    offset: TextSize,
     root_schema: RootSchema,
 ) -> Vec<CompletionItem> {
     let dom = doc.parse.clone().into_dom();
     let paths: HashSet<dom::Path> = dom.iter().map(|(p, _)| p).collect();
-
-    let offset = doc
-        .mapper
-        .offset(taplo::util::coords::Position::from_lsp(position))
-        .unwrap();
-
     let query = dom.query_position(offset);
 
     if !query.is_completable() {


### PR DESCRIPTION
Sometimes Emacs lsp-mode sends a request containing a position parameter before synchronizing with `DidChangeTextDocument`.
At that time, the `mapper` may not be able to find the stored position and panicked with `unwrap`.
This fix is to return `Ok(None)` instead of `unwrap` to avoid this case.

Perhaps this may fix the problem like a https://github.com/golang/go/issues/48249 as well.


This PR includes commit of https://github.com/tamasfe/taplo/pull/184.