### PR TITLE
Make it possible to use !Send even in Native LSP

### DIFF
--- a/lsp-async-stub/Cargo.toml
+++ b/lsp-async-stub/Cargo.toml
@@ -24,12 +24,14 @@ tracing = "0.1.29"
 default = []
 tokio-stdio = [
     "tokio",
+    "tokio/rt",
     "tokio/io-util",
     "tokio/io-std",
     "tokio/macros",
 ]
 tokio-tcp = [
     "tokio",
+    "tokio/rt",
     "tokio/io-util",
     "tokio/net",
     "tokio/macros",

--- a/lsp-async-stub/Cargo.toml
+++ b/lsp-async-stub/Cargo.toml
@@ -22,7 +22,6 @@ tracing = "0.1.29"
 
 [features]
 default = []
-unsend = []
 tokio-stdio = [
     "tokio",
     "tokio/io-util",

--- a/lsp-async-stub/src/handler.rs
+++ b/lsp-async-stub/src/handler.rs
@@ -7,7 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::marker::PhantomData;
 
 #[async_trait(?Send)]
-pub(crate) trait Handler<W: Clone + Send + Sync> {
+pub(crate) trait Handler<W: Clone> {
     fn method(&self) -> &'static str;
 
     async fn handle(
@@ -20,7 +20,7 @@ pub(crate) trait Handler<W: Clone + Send + Sync> {
     fn box_clone(&self) -> Box<dyn Handler<W>>;
 }
 
-impl<W: Clone + Send + Sync> Clone for Box<dyn Handler<W>> {
+impl<W: Clone> Clone for Box<dyn Handler<W>> {
     fn clone(&self) -> Self {
         self.box_clone()
     }
@@ -30,7 +30,7 @@ pub struct RequestHandler<R, F, W>
 where
     R: Request,
     F: Future<Output = Result<R::Result, rpc::Error>>,
-    W: Clone + Send + Sync,
+    W: Clone,
 {
     f: fn(Context<W>, Params<R::Params>) -> F,
     t: PhantomData<W>,
@@ -40,7 +40,7 @@ impl<R, F, W> Clone for RequestHandler<R, F, W>
 where
     R: Request,
     F: Future<Output = Result<R::Result, rpc::Error>>,
-    W: Clone + Send + Sync,
+    W: Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -54,7 +54,7 @@ impl<R, F, W> RequestHandler<R, F, W>
 where
     R: Request,
     F: Future<Output = Result<R::Result, rpc::Error>>,
-    W: Clone + Send + Sync,
+    W: Clone,
 {
     pub fn new(f: fn(Context<W>, Params<R::Params>) -> F) -> Self {
         Self {
@@ -70,7 +70,7 @@ where
     R: Request<Params = P> + 'static,
     P: Serialize + DeserializeOwned + 'static,
     F: Future<Output = Result<R::Result, rpc::Error>> + 'static,
-    W: Clone + Send + Sync + 'static,
+    W: Clone + 'static,
 {
     fn method(&self) -> &'static str {
         R::METHOD
@@ -118,7 +118,7 @@ pub struct NotificationHandler<N, F, W>
 where
     N: Notification,
     F: Future,
-    W: Clone + Send + Sync,
+    W: Clone,
 {
     f: fn(Context<W>, Params<N::Params>) -> F,
     t: PhantomData<W>,
@@ -128,7 +128,7 @@ impl<N, F, W> NotificationHandler<N, F, W>
 where
     N: Notification,
     F: Future,
-    W: Clone + Send + Sync,
+    W: Clone,
 {
     pub fn new(f: fn(Context<W>, Params<N::Params>) -> F) -> Self {
         Self {
@@ -142,7 +142,7 @@ impl<N, F, W> NotificationHandler<N, F, W>
 where
     N: Notification,
     F: Future,
-    W: Clone + Send + Sync,
+    W: Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -158,7 +158,7 @@ where
     N: Notification<Params = P> + 'static,
     P: Serialize + DeserializeOwned + 'static,
     F: Future + 'static,
-    W: Clone + Send + Sync + 'static,
+    W: Clone + 'static,
 {
     fn method(&self) -> &'static str {
         N::METHOD

--- a/lsp-async-stub/src/listen.rs
+++ b/lsp-async-stub/src/listen.rs
@@ -16,7 +16,7 @@ mod stdio;
 #[cfg(feature = "tokio-tcp")]
 mod tcp;
 
-impl<W: Clone + Send + Sync + 'static> Server<W> {
+impl<W: Clone + 'static> Server<W> {
     pub(crate) async fn listen_loop(
         self,
         world: W,

--- a/lsp-async-stub/src/listen.rs
+++ b/lsp-async-stub/src/listen.rs
@@ -40,7 +40,7 @@ impl<W: Clone + Send + Sync + 'static> Server<W> {
                         output.clone().sink_map_err(|e| panic!("{}", e)),
                     );
 
-                    tokio::spawn(async move {
+                    tokio::task::spawn_local(async move {
                         if let Err(e) = task_fut.await {
                             tracing::error!(error = %e, "handler returned error");
                         }
@@ -69,7 +69,7 @@ impl<W: Clone + Send + Sync + 'static> Server<W> {
                                 output.clone().sink_map_err(|e| panic!("{}", e)),
                             );
 
-                            tokio::spawn(async move {
+                            tokio::task::spawn_local(async move {
                                 if let Err(e) = task_fut.await {
                                     tracing::error!(error = %e, "handler returned error");
                                 }

--- a/lsp-async-stub/src/listen/stdio.rs
+++ b/lsp-async-stub/src/listen/stdio.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use futures::Stream;
 
-impl<W: Clone + Send + Sync + 'static> Server<W> {
+impl<W: Clone + 'static> Server<W> {
     pub async fn listen_stdio(
         self,
         world: W,

--- a/lsp-async-stub/src/listen/tcp.rs
+++ b/lsp-async-stub/src/listen/tcp.rs
@@ -5,7 +5,7 @@ use crate::{
 use futures::Stream;
 use tokio::net::{TcpListener, ToSocketAddrs};
 
-impl<W: Clone + Send + Sync + 'static> Server<W> {
+impl<W: Clone + 'static> Server<W> {
     pub async fn listen_tcp<A>(
         self,
         world: W,

--- a/taplo-lsp/Cargo.toml
+++ b/taplo-lsp/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []
-wasm = ["lsp-async-stub/unsend"]
+wasm = []
 
 [dependencies]
 anyhow = "1"

--- a/taplo-lsp/bin/lsp/tcp.rs
+++ b/taplo-lsp/bin/lsp/tcp.rs
@@ -24,8 +24,9 @@ pub(crate) fn run(
     port: usize,
 ) -> i32 {
     let address = format!("{}:{}", addr, port);
+    let local = tokio::task::LocalSet::new();
 
-    rt.block_on(async {
+    local.block_on(&rt, async {
         let listener = match TcpListener::bind(&address).await {
             Ok(l) => l,
             Err(err) => {
@@ -84,12 +85,11 @@ pub(crate) fn run(
                                 output.clone().sink_map_err(|e| panic!("{}", e)),
                             );
 
-                            tokio::spawn(async move {
+                            tokio::task::spawn_local(async move {
                                 if let Err(e) = task_fut.await {
                                     log_error!("{}", e);
                                 }
                             });
-
                         }
                         None => break,
                     }

--- a/taplo-lsp/src/external/native/mod.rs
+++ b/taplo-lsp/src/external/native/mod.rs
@@ -29,8 +29,8 @@ macro_rules! log_debug {
     };
 }
 
-pub(crate) fn spawn<F: Future<Output = ()> + Send + 'static>(fut: F) {
-    tokio::spawn(fut);
+pub(crate) fn spawn<F: Future<Output = ()> + 'static>(fut: F) {
+    tokio::task::spawn_local(fut);
 }
 
 pub(crate) fn is_absolute_path(p: &str) -> bool {

--- a/taplo-lsp/src/external/wasm32/mod.rs
+++ b/taplo-lsp/src/external/wasm32/mod.rs
@@ -73,14 +73,8 @@ extern {
     fn js_is_windows() -> bool;
 }
 
-struct ImplSend<T>(pub T);
-
-// safety: we're in a WASM context with a single thread.
-unsafe impl<T> Send for ImplSend<T> {} 
-unsafe impl<T> Sync for ImplSend<T> {} 
-
-static SERVER: Lazy<ImplSend<Server<World>>> = Lazy::new(|| ImplSend(create_server()));
-static WORLD: Lazy<ImplSend<World>> = Lazy::new(|| ImplSend(create_world()));
+static SERVER: Lazy<Server<World>> = Lazy::new(create_server);
+static WORLD: Lazy<World> = Lazy::new(create_world);
 
 #[wasm_bindgen]
 pub async fn initialize() {


### PR DESCRIPTION
fixes #187

use `tokio::task::spawn_local` and remove `Send` requirements.

Note:
The use of multi-threaded executor is still exists in the following places:
- `create_input`
- `create_output`
- `taplo-cli`
