### PR TITLE
Update rustfmt.toml.json

### DIFF
--- a/schemas/rustfmt.toml.json
+++ b/schemas/rustfmt.toml.json
@@ -8,406 +8,467 @@
     "patterns": ["^(.*(/|\\\\)rustfmt\\.toml|rustfmt\\.toml)$"]
   },
   "properties": {
+    "array_width": {
+      "type": "integer",
+      "description": "Maximum width of an array literal before falling back to vertical formatting.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#array_width)",
+      "default": 60
+    },
+    "attr_fn_like_width": {
+      "type": "integer",
+      "description": "Maximum width of the args of a function-like attributes before falling back to vertical formatting.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#attr_fn_like_width)",
+      "default": 70
+    },
+    "binop_separator": {
+      "type": "string",
+      "description": "Where to put a binary operator when a binary expression goes multiline\n\n[Documentation](https://rust-lang.github.io/rustfmt/#binop_separator)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Front",
+      "enum": ["Front", "Back"]
+    },
+    "blank_lines_lower_bound": {
+      "type": "integer",
+      "description": "Minimum number of blank lines which must be put between items\n\n[Documentation](https://rust-lang.github.io/rustfmt/#blank_lines_lower_bound)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": 0
+    },
+    "blank_lines_upper_bound": {
+      "type": "integer",
+      "description": "Maximum number of blank lines which can be put between items\n\n[Documentation](https://rust-lang.github.io/rustfmt/#blank_lines_upper_bound)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": 1
+    },
+    "brace_style": {
+      "type": "string",
+      "description": "Brace style for items\n\n[Documentation](https://rust-lang.github.io/rustfmt/#brace_style)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "SameLineWhere",
+      "enum": ["AlwaysNextLine", "PreferSameLine", "SameLineWhere"]
+    },
+    "chain_width": {
+      "type": "integer",
+      "description": "Maximum length of a chain to fit on a single line.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#chain_width)",
+      "default": 60
+    },
+    "color": {
+      "type": "string",
+      "description": "What Color option to use when none is supplied: Always, Never, Auto\n\n[Documentation](https://rust-lang.github.io/rustfmt/#color)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Auto",
+      "enum": ["Always", "Never", "Auto"]
+    },
+    "combine_control_expr": {
+      "type": "boolean",
+      "description": "Combine control expressions with function calls\n\n[Documentation](https://rust-lang.github.io/rustfmt/#combine_control_expr)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": true,
+      "enum": [true, false]
+    },
     "comment_width": {
       "type": "integer",
-      "description": "Maximum length of comments. No effect unless wrap_comments = true\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Maximum length of comments. No effect unless wrap_comments = true\n\n[Documentation](https://rust-lang.github.io/rustfmt/#comment_width)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": 80
     },
-    "trailing_semicolon": {
+    "condense_wildcard_suffixes": {
       "type": "boolean",
-      "description": "Add trailing semicolon after break, continue and return\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": true,
-      "enum": [true, false]
-    },
-    "merge_derives": {
-      "type": "boolean",
-      "description": "Merge multiple `#[derive(...)]` into a single one",
-      "default": true,
-      "enum": [true, false]
-    },
-    "normalize_doc_attributes": {
-      "type": "boolean",
-      "description": "Normalize doc attributes as doc comments\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Replace strings of _ wildcards by a single .. in tuple patterns\n\n[Documentation](https://rust-lang.github.io/rustfmt/#condense_wildcard_suffixes)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
       "enum": [true, false]
     },
     "control_brace_style": {
       "type": "string",
-      "description": "Brace style for control flow constructs\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Brace style for control flow constructs\n\n[Documentation](https://rust-lang.github.io/rustfmt/#control_brace_style)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": "AlwaysSameLine",
       "enum": ["AlwaysSameLine", "ClosingNextLine", "AlwaysNextLine"]
     },
-    "binop_separator": {
+    "disable_all_formatting": {
+      "type": "boolean",
+      "description": "Don't reformat anything\n\n[Documentation](https://rust-lang.github.io/rustfmt/#disable_all_formatting)",
+      "default": false,
+      "enum": [true, false]
+    },
+    "edition": {
       "type": "string",
-      "description": "Where to put a binary operator when a binary expression goes multiline\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Front",
-      "enum": ["Front", "Back"]
+      "description": "The edition of the parser (RFC 2052)\n\n[Documentation](https://rust-lang.github.io/rustfmt/#edition)",
+      "default": "2015",
+      "enum": ["2015", "2018", "2021"]
     },
-    "reorder_impl_items": {
-      "type": "boolean",
-      "description": "Reorder impl items\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "space_after_colon": {
-      "type": "boolean",
-      "description": "Leave a space after the colon\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": true,
-      "enum": [true, false]
-    },
-    "match_arm_blocks": {
-      "type": "boolean",
-      "description": "Wrap the body of arms in blocks when it does not fit on the same line with the pattern of arms\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": true,
-      "enum": [true, false]
-    },
-    "space_before_colon": {
-      "type": "boolean",
-      "description": "Leave a space before the colon\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "max_width": {
-      "type": "integer",
-      "description": "Maximum width of each line",
-      "default": 100
+    "emit_mode": {
+      "type": "string",
+      "description": "What emit Mode to use when none is supplied\n\n[Documentation](https://rust-lang.github.io/rustfmt/#emit_mode)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Files",
+      "enum": [
+        "Files",
+        "Stdout",
+        "Coverage",
+        "Checkstyle",
+        "Json",
+        "ModifiedLines",
+        "Diff"
+      ]
     },
     "empty_item_single_line": {
       "type": "boolean",
-      "description": "Put empty-body functions and impls on a single line\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Put empty-body functions and impls on a single line\n\n[Documentation](https://rust-lang.github.io/rustfmt/#empty_item_single_line)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": true,
       "enum": [true, false]
     },
-    "force_explicit_abi": {
-      "type": "boolean",
-      "description": "Always print the abi for extern items",
-      "default": true,
-      "enum": [true, false]
-    },
-    "hard_tabs": {
-      "type": "boolean",
-      "description": "Use tab characters for indentation, spaces for alignment",
-      "default": false,
-      "enum": [true, false]
-    },
-    "imports_indent": {
-      "type": "string",
-      "description": "Indent of imports\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Block",
-      "enum": ["Visual", "Block"]
-    },
-    "struct_lit_single_line": {
-      "type": "boolean",
-      "description": "Put small struct literals on a single line\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": true,
-      "enum": [true, false]
-    },
-    "skip_children": {
-      "type": "boolean",
-      "description": "Don't reformat out of line modules\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "reorder_imports": {
-      "type": "boolean",
-      "description": "Reorder import and extern crate statements alphabetically",
-      "default": true,
-      "enum": [true, false]
-    },
-    "imports_layout": {
-      "type": "string",
-      "description": "Item layout inside a import block\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Mixed",
-      "enum": ["Vertical", "Horizontal", "HorizontalVertical", "LimitedHorizontalVertical", "Mixed"]
-    },
-    "trailing_comma": {
-      "type": "string",
-      "description": "How to handle trailing commas for lists\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Vertical",
-      "enum": ["Always", "Never", "Vertical"]
-    },
-    "use_field_init_shorthand": {
-      "type": "boolean",
-      "description": "Use field initialization shorthand if possible",
-      "default": false,
-      "enum": [true, false]
-    },
-    "wrap_comments": {
-      "type": "boolean",
-      "description": "Break comments to fit on the line\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "imports_granularity": {
-      "type": "string",
-      "description": "Merge or split imports to the provided granularity\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Preserve",
-      "enum": ["Preserve", "Crate", "Module", "Item"]
-    },
-    "blank_lines_upper_bound": {
+    "enum_discrim_align_threshold": {
       "type": "integer",
-      "description": "Maximum number of blank lines which can be put between items\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": 1
+      "description": "Align enum variants discrims, if their diffs fit within threshold\n\n[Documentation](https://rust-lang.github.io/rustfmt/#enum_discrim_align_threshold)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": 0
     },
-    "format_code_in_doc_comments": {
+    "error_on_line_overflow": {
       "type": "boolean",
-      "description": "Format the code snippet in doc comments.\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Error if unable to get all lines within max_width\n\n[Documentation](https://rust-lang.github.io/rustfmt/#error_on_line_overflow)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
       "enum": [true, false]
     },
     "error_on_unformatted": {
       "type": "boolean",
-      "description": "Error if unable to get comments or string literals within max_width, or they are left with trailing whitespaces\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Error if unable to get comments or string literals within max_width, or they are left with trailing whitespaces\n\n[Documentation](https://rust-lang.github.io/rustfmt/#error_on_unformatted)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
+      "enum": [true, false]
+    },
+    "fn_args_layout": {
+      "type": "string",
+      "description": "Control the layout of arguments in a function\n\n[Documentation](https://rust-lang.github.io/rustfmt/#fn_args_layout)",
+      "default": "Tall",
+      "enum": ["Compressed", "Tall", "Vertical"]
+    },
+    "fn_call_width": {
+      "type": "integer",
+      "description": "Maximum width of the args of a function call before falling back to vertical formatting.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#fn_call_width)",
+      "default": 60
+    },
+    "fn_single_line": {
+      "type": "boolean",
+      "description": "Put single-expression functions on a single line\n\n[Documentation](https://rust-lang.github.io/rustfmt/#fn_single_line)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "force_explicit_abi": {
+      "type": "boolean",
+      "description": "Always print the abi for extern items\n\n[Documentation](https://rust-lang.github.io/rustfmt/#force_explicit_abi)",
+      "default": true,
       "enum": [true, false]
     },
     "force_multiline_blocks": {
       "type": "boolean",
-      "description": "Force multiline closure bodies and match arms to be wrapped in a block\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Force multiline closure bodies and match arms to be wrapped in a block\n\n[Documentation](https://rust-lang.github.io/rustfmt/#force_multiline_blocks)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
       "enum": [true, false]
     },
-    "disable_all_formatting": {
+    "format_code_in_doc_comments": {
       "type": "boolean",
-      "description": "Don't reformat anything\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Format the code snippet in doc comments.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#format_code_in_doc_comments)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "format_generated_files": {
+      "type": "boolean",
+      "description": "Format generated files\n\n[Documentation](https://rust-lang.github.io/rustfmt/#format_generated_files)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": true,
+      "enum": [true, false]
+    },
+    "format_macro_bodies": {
+      "type": "boolean",
+      "description": "Format the bodies of macros\n\n[Documentation](https://rust-lang.github.io/rustfmt/#format_macro_bodies)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": true,
+      "enum": [true, false]
+    },
+    "format_macro_matchers": {
+      "type": "boolean",
+      "description": "Format the metavariable matching patterns in macros\n\n[Documentation](https://rust-lang.github.io/rustfmt/#format_macro_matchers)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "format_strings": {
+      "type": "boolean",
+      "description": "Format string literals where necessary\n\n[Documentation](https://rust-lang.github.io/rustfmt/#format_strings)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
       "enum": [true, false]
     },
     "group_imports": {
       "type": "string",
-      "description": "Controls the strategy for how imports are grouped together\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Controls the strategy for how imports are grouped together\n\n[Documentation](https://rust-lang.github.io/rustfmt/#group_imports)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": "Preserve",
-      "enum": ["Preserve", "StdExternalCrate"]
+      "enum": ["Preserve", "StdExternalCrate", "One"]
     },
-    "indent_style": {
-      "type": "string",
-      "description": "How do we indent expressions or items\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Block",
-      "enum": ["Visual", "Block"]
-    },
-    "format_strings": {
+    "hard_tabs": {
       "type": "boolean",
-      "description": "Format string literals where necessary\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Use tab characters for indentation, spaces for alignment\n\n[Documentation](https://rust-lang.github.io/rustfmt/#hard_tabs)",
       "default": false,
       "enum": [true, false]
     },
-    "unstable_features": {
-      "type": "boolean",
-      "description": "Enables unstable features. Only available on nightly channel\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "report_fixme": {
+    "hex_literal_case": {
       "type": "string",
-      "description": "Report all, none or unnumbered occurrences of FIXME in source file comments\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Never",
-      "enum": ["Always", "Unnumbered", "Never"]
-    },
-    "brace_style": {
-      "type": "string",
-      "description": "Brace style for items\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "SameLineWhere",
-      "enum": ["AlwaysNextLine", "PreferSameLine", "SameLineWhere"]
-    },
-    "inline_attribute_width": {
-      "type": "integer",
-      "description": "Write an item and its attribute on the same line if their combined width is below a threshold\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": 0
-    },
-    "fn_single_line": {
-      "type": "boolean",
-      "description": "Put single-expression functions on a single line\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "version": {
-      "type": "string",
-      "description": "Version of formatting rules\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "One",
-      "enum": ["One", "Two"]
-    },
-    "condense_wildcard_suffixes": {
-      "type": "boolean",
-      "description": "Replace strings of _ wildcards by a single .. in tuple patterns\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "use_small_heuristics": {
-      "type": "string",
-      "description": "Whether to use different formatting for items and expressions if they satisfy a heuristic notion of 'small'",
-      "default": "Default",
-      "enum": ["Off", "Max", "Default"]
-    },
-    "use_try_shorthand": {
-      "type": "boolean",
-      "description": "Replace uses of the try! macro by the ? shorthand",
-      "default": false,
-      "enum": [true, false]
-    },
-    "emit_mode": {
-      "type": "string",
-      "description": "What emit Mode to use when none is supplied\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Files",
-      "enum": ["Files", "Stdout", "Coverage", "Checkstyle", "Json", "ModifiedLines", "Diff"]
-    },
-    "type_punctuation_density": {
-      "type": "string",
-      "description": "Determines if '+' or '=' are wrapped in spaces in the punctuation of types\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Wide",
-      "enum": ["Compressed", "Wide"]
-    },
-    "color": {
-      "type": "string",
-      "description": "What Color option to use when none is supplied: Always, Never, Auto\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Auto",
-      "enum": ["Always", "Never", "Auto"]
-    },
-    "make_backup": {
-      "type": "boolean",
-      "description": "Backup changed files\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "tab_spaces": {
-      "type": "integer",
-      "description": "Number of spaces per tab",
-      "default": 4
-    },
-    "normalize_comments": {
-      "type": "boolean",
-      "description": "Convert /* */ comments to // comments where possible\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "overflow_delimited_expr": {
-      "type": "boolean",
-      "description": "Allow trailing bracket/brace delimited expressions to overflow\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "enum_discrim_align_threshold": {
-      "type": "integer",
-      "description": "Align enum variants discrims, if their diffs fit within threshold\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": 0
-    },
-    "required_version": {
-      "type": "string",
-      "description": "Require a specific version of rustfmt\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "1.4.34"
+      "description": "Format hexadecimal integer literals\n\n[Documentation](https://rust-lang.github.io/rustfmt/#hex_literal_case)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Preserve",
+      "enum": ["Preserve", "Upper", "Lower"]
     },
     "hide_parse_errors": {
       "type": "boolean",
-      "description": "Hide errors from the parser\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Hide errors from the parser\n\n[Documentation](https://rust-lang.github.io/rustfmt/#hide_parse_errors)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
-      "enum": [true, false]
-    },
-    "print_misformatted_file_names": {
-      "type": "boolean",
-      "description": "Prints the names of mismatched files that were formatted. Prints the names of files that would be formated when used with `--check` mode.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "reorder_modules": {
-      "type": "boolean",
-      "description": "Reorder module statements alphabetically in group",
-      "default": true,
-      "enum": [true, false]
-    },
-    "license_template_path": {
-      "type": "string",
-      "description": "Beginning of file must match license template\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "\"\""
-    },
-    "error_on_line_overflow": {
-      "type": "boolean",
-      "description": "Error if unable to get all lines within max_width\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "newline_style": {
-      "type": "string",
-      "description": "Unix or Windows line endings",
-      "default": "Auto",
-      "enum": ["Auto", "Windows", "Unix", "Native"]
-    },
-    "format_macro_matchers": {
-      "type": "boolean",
-      "description": "Format the metavariable matching patterns in macros\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "combine_control_expr": {
-      "type": "boolean",
-      "description": "Combine control expressions with function calls\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": true,
       "enum": [true, false]
     },
     "ignore": {
       "type": "array",
-      "description": "Skip formatting the specified files and directories\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Skip formatting the specified files and directories\n\n[Documentation](https://rust-lang.github.io/rustfmt/#ignore)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": []
     },
-    "remove_nested_parens": {
-      "type": "boolean",
-      "description": "Remove nested parens",
-      "default": true,
-      "enum": [true, false]
+    "imports_granularity": {
+      "type": "string",
+      "description": "Merge or split imports to the provided granularity\n\n[Documentation](https://rust-lang.github.io/rustfmt/#imports_granularity)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Preserve",
+      "enum": ["Preserve", "Crate", "Module", "Item", "One"]
     },
-    "match_block_trailing_comma": {
+    "imports_indent": {
+      "type": "string",
+      "description": "Indent of imports\n\n[Documentation](https://rust-lang.github.io/rustfmt/#imports_indent)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Block",
+      "enum": ["Visual", "Block"]
+    },
+    "imports_layout": {
+      "type": "string",
+      "description": "Item layout inside a import block\n\n[Documentation](https://rust-lang.github.io/rustfmt/#imports_layout)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Mixed",
+      "enum": [
+        "Vertical",
+        "Horizontal",
+        "HorizontalVertical",
+        "LimitedHorizontalVertical",
+        "Mixed"
+      ]
+    },
+    "indent_style": {
+      "type": "string",
+      "description": "How do we indent expressions or items\n\n[Documentation](https://rust-lang.github.io/rustfmt/#indent_style)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Block",
+      "enum": ["Visual", "Block"]
+    },
+    "inline_attribute_width": {
+      "type": "integer",
+      "description": "Write an item and its attribute on the same line if their combined width is below a threshold\n\n[Documentation](https://rust-lang.github.io/rustfmt/#inline_attribute_width)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": 0
+    },
+    "license_template_path": {
+      "type": "string",
+      "description": "Beginning of file must match license template\n\n[Documentation](https://rust-lang.github.io/rustfmt/#license_template_path)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "\"\""
+    },
+    "make_backup": {
       "type": "boolean",
-      "description": "Put a trailing comma after a block based match arm (non-block arms are not affected)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Backup changed files\n\n[Documentation](https://rust-lang.github.io/rustfmt/#make_backup)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
       "enum": [true, false]
     },
-    "blank_lines_lower_bound": {
-      "type": "integer",
-      "description": "Minimum number of blank lines which must be put between items\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": 0
-    },
-    "report_todo": {
-      "type": "string",
-      "description": "Report all, none or unnumbered occurrences of TODO in source file comments\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": "Never",
-      "enum": ["Always", "Unnumbered", "Never"]
-    },
-    "spaces_around_ranges": {
+    "match_arm_blocks": {
       "type": "boolean",
-      "description": "Put spaces around the  .. and ..= range operators\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": false,
-      "enum": [true, false]
-    },
-    "struct_field_align_threshold": {
-      "type": "integer",
-      "description": "Align struct fields if their diffs fits within threshold\n\n### Unstable\nThis option requires Nightly Rust.",
-      "default": 0
-    },
-    "fn_args_layout": {
-      "type": "string",
-      "description": "Control the layout of arguments in a function",
-      "default": "Tall",
-      "enum": ["Compressed", "Tall", "Vertical"]
-    },
-    "format_macro_bodies": {
-      "type": "boolean",
-      "description": "Format the bodies of macros\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Wrap the body of arms in blocks when it does not fit on the same line with the pattern of arms\n\n[Documentation](https://rust-lang.github.io/rustfmt/#match_arm_blocks)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": true,
       "enum": [true, false]
     },
     "match_arm_leading_pipes": {
       "type": "string",
-      "description": "Determines whether leading pipes are emitted on match arms",
+      "description": "Determines whether leading pipes are emitted on match arms\n\n[Documentation](https://rust-lang.github.io/rustfmt/#match_arm_leading_pipes)",
       "default": "Never",
       "enum": ["Always", "Never", "Preserve"]
     },
-    "edition": {
+    "match_block_trailing_comma": {
+      "type": "boolean",
+      "description": "Put a trailing comma after a block based match arm (non-block arms are not affected)\n\n[Documentation](https://rust-lang.github.io/rustfmt/#match_block_trailing_comma)",
+      "default": false,
+      "enum": [true, false]
+    },
+    "max_width": {
+      "type": "integer",
+      "description": "Maximum width of each line\n\n[Documentation](https://rust-lang.github.io/rustfmt/#max_width)",
+      "default": 100
+    },
+    "merge_derives": {
+      "type": "boolean",
+      "description": "Merge multiple `#[derive(...)]` into a single one\n\n[Documentation](https://rust-lang.github.io/rustfmt/#merge_derives)",
+      "default": true,
+      "enum": [true, false]
+    },
+    "newline_style": {
       "type": "string",
-      "description": "The edition of the parser (RFC 2052)",
-      "default": "2015",
-      "enum": ["2015", "2018", "2021"]
+      "description": "Unix or Windows line endings\n\n[Documentation](https://rust-lang.github.io/rustfmt/#newline_style)",
+      "default": "Auto",
+      "enum": ["Auto", "Windows", "Unix", "Native"]
+    },
+    "normalize_comments": {
+      "type": "boolean",
+      "description": "Convert /* */ comments to // comments where possible\n\n[Documentation](https://rust-lang.github.io/rustfmt/#normalize_comments)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "normalize_doc_attributes": {
+      "type": "boolean",
+      "description": "Normalize doc attributes as doc comments\n\n[Documentation](https://rust-lang.github.io/rustfmt/#normalize_doc_attributes)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "overflow_delimited_expr": {
+      "type": "boolean",
+      "description": "Allow trailing bracket/brace delimited expressions to overflow\n\n[Documentation](https://rust-lang.github.io/rustfmt/#overflow_delimited_expr)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "print_misformatted_file_names": {
+      "type": "boolean",
+      "description": "Prints the names of mismatched files that were formatted. Prints the names of files that would be formated when used with `--check` mode.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#print_misformatted_file_names)",
+      "default": false,
+      "enum": [true, false]
+    },
+    "remove_nested_parens": {
+      "type": "boolean",
+      "description": "Remove nested parens\n\n[Documentation](https://rust-lang.github.io/rustfmt/#remove_nested_parens)",
+      "default": true,
+      "enum": [true, false]
+    },
+    "reorder_impl_items": {
+      "type": "boolean",
+      "description": "Reorder impl items\n\n[Documentation](https://rust-lang.github.io/rustfmt/#reorder_impl_items)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "reorder_imports": {
+      "type": "boolean",
+      "description": "Reorder import and extern crate statements alphabetically\n\n[Documentation](https://rust-lang.github.io/rustfmt/#reorder_imports)",
+      "default": true,
+      "enum": [true, false]
+    },
+    "reorder_modules": {
+      "type": "boolean",
+      "description": "Reorder module statements alphabetically in group\n\n[Documentation](https://rust-lang.github.io/rustfmt/#reorder_modules)",
+      "default": true,
+      "enum": [true, false]
+    },
+    "report_fixme": {
+      "type": "string",
+      "description": "Report all, none or unnumbered occurrences of FIXME in source file comments\n\n[Documentation](https://rust-lang.github.io/rustfmt/#report_fixme)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Never",
+      "enum": ["Always", "Unnumbered", "Never"]
+    },
+    "report_todo": {
+      "type": "string",
+      "description": "Report all, none or unnumbered occurrences of TODO in source file comments\n\n[Documentation](https://rust-lang.github.io/rustfmt/#report_todo)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Never",
+      "enum": ["Always", "Unnumbered", "Never"]
+    },
+    "required_version": {
+      "type": "string",
+      "description": "Require a specific version of rustfmt\n\n[Documentation](https://rust-lang.github.io/rustfmt/#required_version)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "1.4.38"
+    },
+    "single_line_if_else_max_width": {
+      "type": "integer",
+      "description": "Maximum line length for single line if-else expressions. A value of zero means always break if-else expressions.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#single_line_if_else_max_width)",
+      "default": 50
+    },
+    "skip_children": {
+      "type": "boolean",
+      "description": "Don't reformat out of line modules\n\n[Documentation](https://rust-lang.github.io/rustfmt/#skip_children)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "space_after_colon": {
+      "type": "boolean",
+      "description": "Leave a space after the colon\n\n[Documentation](https://rust-lang.github.io/rustfmt/#space_after_colon)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": true,
+      "enum": [true, false]
+    },
+    "space_before_colon": {
+      "type": "boolean",
+      "description": "Leave a space before the colon\n\n[Documentation](https://rust-lang.github.io/rustfmt/#space_before_colon)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "spaces_around_ranges": {
+      "type": "boolean",
+      "description": "Put spaces around the  .. and ..= range operators\n\n[Documentation](https://rust-lang.github.io/rustfmt/#spaces_around_ranges)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "struct_field_align_threshold": {
+      "type": "integer",
+      "description": "Align struct fields if their diffs fits within threshold\n\n[Documentation](https://rust-lang.github.io/rustfmt/#struct_field_align_threshold)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": 0
+    },
+    "struct_lit_single_line": {
+      "type": "boolean",
+      "description": "Put small struct literals on a single line\n\n[Documentation](https://rust-lang.github.io/rustfmt/#struct_lit_single_line)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": true,
+      "enum": [true, false]
+    },
+    "struct_lit_width": {
+      "type": "integer",
+      "description": "Maximum width in the body of a struct lit before falling back to vertical formatting.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#struct_lit_width)",
+      "default": 18
+    },
+    "struct_variant_width": {
+      "type": "integer",
+      "description": "Maximum width in the body of a struct variant before falling back to vertical formatting.\n\n[Documentation](https://rust-lang.github.io/rustfmt/#struct_variant_width)",
+      "default": 35
+    },
+    "tab_spaces": {
+      "type": "integer",
+      "description": "Number of spaces per tab\n\n[Documentation](https://rust-lang.github.io/rustfmt/#tab_spaces)",
+      "default": 4
+    },
+    "trailing_comma": {
+      "type": "string",
+      "description": "How to handle trailing commas for lists\n\n[Documentation](https://rust-lang.github.io/rustfmt/#trailing_comma)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Vertical",
+      "enum": ["Always", "Never", "Vertical"]
+    },
+    "trailing_semicolon": {
+      "type": "boolean",
+      "description": "Add trailing semicolon after break, continue and return\n\n[Documentation](https://rust-lang.github.io/rustfmt/#trailing_semicolon)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": true,
+      "enum": [true, false]
+    },
+    "type_punctuation_density": {
+      "type": "string",
+      "description": "Determines if '+' or '=' are wrapped in spaces in the punctuation of types\n\n[Documentation](https://rust-lang.github.io/rustfmt/#type_punctuation_density)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "Wide",
+      "enum": ["Compressed", "Wide"]
+    },
+    "unstable_features": {
+      "type": "boolean",
+      "description": "Enables unstable features. Only available on nightly channel\n\n[Documentation](https://rust-lang.github.io/rustfmt/#unstable_features)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "use_field_init_shorthand": {
+      "type": "boolean",
+      "description": "Use field initialization shorthand if possible\n\n[Documentation](https://rust-lang.github.io/rustfmt/#use_field_init_shorthand)",
+      "default": false,
+      "enum": [true, false]
+    },
+    "use_small_heuristics": {
+      "type": "string",
+      "description": "Whether to use different formatting for items and expressions if they satisfy a heuristic notion of 'small'\n\n[Documentation](https://rust-lang.github.io/rustfmt/#use_small_heuristics)",
+      "default": "Default",
+      "enum": ["Off", "Max", "Default"]
+    },
+    "use_try_shorthand": {
+      "type": "boolean",
+      "description": "Replace uses of the try! macro by the ? shorthand\n\n[Documentation](https://rust-lang.github.io/rustfmt/#use_try_shorthand)",
+      "default": false,
+      "enum": [true, false]
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of formatting rules\n\n[Documentation](https://rust-lang.github.io/rustfmt/#version)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": "One",
+      "enum": ["One", "Two"]
     },
     "where_single_line": {
       "type": "boolean",
-      "description": "Force where-clauses to be on a single line\n\n### Unstable\nThis option requires Nightly Rust.",
+      "description": "Force where-clauses to be on a single line\n\n[Documentation](https://rust-lang.github.io/rustfmt/#where_single_line)\n\n### Unstable\nThis option requires Nightly Rust.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "wrap_comments": {
+      "type": "boolean",
+      "description": "Break comments to fit on the line\n\n[Documentation](https://rust-lang.github.io/rustfmt/#wrap_comments)\n\n### Unstable\nThis option requires Nightly Rust.",
       "default": false,
       "enum": [true, false]
     }


### PR DESCRIPTION
This updates the rustfmt schema to include the latest rustfmt features (9 added options and 2 stabilized), and to add a `Documentation` link to each item.

This schema was generated with [rustfmt-schema-maker](https://github.com/Aloso/rustfmt-schema-maker) and then formatted with prettier.

The diff is unfortunately bigger than necessary. The reason is that I previously used a `HashMap` for the items, so the order was unstable. I switched to a `BTreeMap`, so they are now sorted, so the next time the schema is updated, the diff will be smaller. [Here](https://github.com/Aloso/rustfmt-schema-maker/commit/204d0d88ec4b9efe520c4f9cec6211791949f064#diff-3d952971f8702bc3d22a84e30fcbc491bdfb69bbf340eb4be2dea3c135a4782c) is a more readable diff that doesn't reorder the items.