### PR TITLE
Swaps over from `variable.key.toml` to `support.type.property-name.toml` in vscode grammar

### DIFF
--- a/js/vscode/src/syntax/composite/entry.ts
+++ b/js/vscode/src/syntax/composite/entry.ts
@@ -6,7 +6,7 @@ export const entryBegin = {
       patterns: [
         {
           match: "[^\\s.]+",
-          name: "variable.key.toml",
+          name: "support.type.property-name.toml",
         },
         {
           match: "\\.",

--- a/js/vscode/toml.tmLanguage.json
+++ b/js/vscode/toml.tmLanguage.json
@@ -137,7 +137,7 @@
           "patterns": [
             {
               "match": "[^\\s.]+",
-              "name": "variable.key.toml"
+              "name": "support.type.property-name.toml"
             },
             {
               "match": "\\.",


### PR DESCRIPTION
This should provide a much better experience when syntax highlighting in vscode. Most(but not all) themes treat `variable.key` and `variable.key.table` the same(no highlighting for either), which makes for an inconsistent and poorly supported syntax highlighting experience. As mentioned in #143 is what the json grammar uses as well.