### PR TITLE
Add support  for `.rustfmt.toml`

### DIFF
--- a/schemas/rustfmt.toml.json
+++ b/schemas/rustfmt.toml.json
@@ -5,7 +5,7 @@
   "description": "https://rust-lang.github.io/rustfmt",
   "x-taplo-info": {
     "authors": ["Aloso (https://github.com/Aloso)"],
-    "patterns": ["^(.*(/|\\\\).?rustfmt\\.toml|rustfmt\\.toml)$"]
+    "patterns": ["^(.*(/|\\\\)\\.?rustfmt\\.toml|rustfmt\\.toml)$"]
   },
   "properties": {
     "array_width": {

--- a/schemas/rustfmt.toml.json
+++ b/schemas/rustfmt.toml.json
@@ -5,7 +5,7 @@
   "description": "https://rust-lang.github.io/rustfmt",
   "x-taplo-info": {
     "authors": ["Aloso (https://github.com/Aloso)"],
-    "patterns": ["^(.*(/|\\\\)rustfmt\\.toml|rustfmt\\.toml)$"]
+    "patterns": ["^(.*(/|\\\\).?rustfmt\\.toml|rustfmt\\.toml)$"]
   },
   "properties": {
     "array_width": {


### PR DESCRIPTION
Add support for Rustfmt configuration file with a leading dot `.rustfmt.toml`, in addition to one without `rustfmt.toml`.