### PR TITLE
Add initial `rust-toolchain.toml` schema

### DIFF
--- a/schemas/rust-toolchain.toml.json
+++ b/schemas/rust-toolchain.toml.json
@@ -12,14 +12,14 @@
   },
   "properties": {
     "toolchain": {
-      "description": "The Rust toolchain to be used.",
+      "description": "A \"toolchain\" is a complete installation of the Rust\ncompiler (`rustc`) and related tools (like `cargo`). A toolchain\nspecification includes the release channel or version, and the host\nplatform that the toolchain runs on.",
       "type": "object",
       "minProperties": 1,
       "oneOf": [
         {
           "properties": {
             "channel": {
-              "description": "The release channel of Rust to use.",
+              "description": "Rust is released to three different \"channels\": stable, beta,\nand nightly.",
               "type": "string",
               "oneOf": [
                 {
@@ -36,14 +36,11 @@
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/concepts/channels.html"
-                },
-                "docs": {
-                  "main": "Rust is released to three different \"channels\": stable, beta,\nand nightly."
                 }
               }
             },
             "components": {
-              "description": "Components to be installed as part of the toolchain.",
+              "description": "Each release of Rust includes several \"components\", some of\nwhich are required (like `rustc`) and some that are optional (like\n[`clippy`][clippy]).\n\n[clippy]: https://github.com/rust-lang/rust-clippy",
               "type": "array",
               "items": {
                 "type": "string",
@@ -67,7 +64,7 @@
                     "x-taplo": {
                       "docs": {
                         "enumValues": [
-                          "The Rust compiler and [Rustdoc].\n[rustdoc]: https://doc.rust-lang.org/rustdoc/",
+                          "The Rust compiler and [Rustdoc].\n\n[rustdoc]: https://doc.rust-lang.org/rustdoc/",
                           "[Cargo] is a package manager and build tool.\n\n[cargo]: https://doc.rust-lang.org/cargo/",
                           "[Rustfmt] is a tool for automatically formatting code.\n\n[rustfmt]: https://github.com/rust-lang/rustfmt",
                           "This is the Rust [standard library]. There is a separate\n  `rust-std` component for each target that `rustc` supports, such as\n  `rust-std-x86_64-pc-windows-msvc`. See the [Cross-compilation] chapter for\n  more detail.\n\n[standard library]: https://doc.rust-lang.org/std/\n[cross-compilation]: .https://rust-lang.github.io/rustup/cross-compilation.html",
@@ -92,14 +89,11 @@
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/concepts/components.html"
-                },
-                "docs": {
-                  "main": "Each release of Rust includes several \"components\", some of\nwhich are required (like `rustc`) and some that are optional (like\n[`clippy`])."
                 }
               }
             },
             "targets": {
-              "description": "Additional platforms to install the toolchain for.",
+              "description": "`rustc` is capable of generating code for many platforms. The\n\"target\" specifies the platform that the code will be generated for. By\ndefault, `cargo` and `rustc` use the host toolchain's platform as the\ntarget. To build for a different target, usually the target's standard\nlibrary needs to be installed first via the `rustup target` command.",
               "type": "array",
               "items": {
                 "oneOf": [
@@ -294,14 +288,11 @@
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/cross-compilation.html"
-                },
-                "docs": {
-                  "main": "`rustc` is capable of generating code for many platforms. The\n\"target\" specifies the platform that the code will be generated for. By\ndefault, `cargo` and `rustc` use the host toolchain's platform as the\ntarget. To build for a different target, usually the target's standard\nlibrary needs to be installed first via the `rustup target` command."
                 }
               }
             },
             "profile": {
-              "description": "The set of components to install when installing the toolchain.",
+              "description": "In order to make it easier to work with components, a\n\"profile\" defines a grouping of components.",
               "type": "string",
               "default": "default",
               "enum": [
@@ -314,7 +305,6 @@
                   "key": "https://rust-lang.github.io/rustup/concepts/profiles.html"
                 },
                 "docs": {
-                  "main": "In order to make it easier to work with components, a\n\"profile\" defines a grouping of components.",
                   "enumValues": [
                     "This profile includes as few components as possible to get a\nworking compiler (`rustc`, `rust-std`, and `cargo`). It's recommended to use\nthis component on Windows systems if you don't use local documentation (the\nlarge number of files can cause issues with some Antivirus systems), and in\nCI.",
                     "This profile includes all of components in the **minimal**\nprofile, and adds `rust-docs`, `rustfmt`, and `clippy`. This profile will be\nused by `rustup` by default, and it's the one recommended for general use.",
@@ -332,12 +322,7 @@
           "properties": {
             "path": {
               "type": "string",
-              "description": "Path to a custom local toolchain.",
-              "x-taplo": {
-                "docs": {
-                  "main": "Path to a custom local toolchain. Since a `path` directive directly names a local toolchain, other options\nlike `components`, `targets`, and `profile` have no effect. `channel`\nand `path` are mutually exclusive, since a `path` already points to a\nspecific toolchain. A relative `path` is resolved relative to the\nlocation of the `rust-toolchain.toml` file."
-                }
-              }
+              "description": "Path to a custom local toolchain. Since a `path` directive directly names a local toolchain, other options\nlike `components`, `targets`, and `profile` have no effect. `channel`\nand `path` are mutually exclusive, since a `path` already points to a\nspecific toolchain. A relative `path` is resolved relative to the\nlocation of the `rust-toolchain.toml` file."
             }
           },
           "required": [
@@ -351,10 +336,7 @@
         },
         "initKeys": [
           "channel"
-        ],
-        "docs": {
-          "main": "A \"toolchain\" is a complete installation of the Rust\ncompiler (`rustc`) and related tools (like `cargo`). A toolchain\nspecification includes the release channel or version, and the host\nplatform that the toolchain runs on."
-        }
+        ]
       }
     }
   },

--- a/schemas/rust-toolchain.toml.json
+++ b/schemas/rust-toolchain.toml.json
@@ -12,7 +12,7 @@
   },
   "properties": {
     "toolchain": {
-      "description": "Details about the Rust toolchain to be used.",
+      "description": "The Rust toolchain to be used.",
       "type": "object",
       "minProperties": 1,
       "oneOf": [
@@ -27,21 +27,23 @@
                     "stable",
                     "beta",
                     "nightly"
-                  ],
-                  "$comment": "TODO: enumValues docs? or maybe not"
+                  ]
                 },
                 {
-                  "$comment": "Empty schema allows for custom rustup toolchains with `rustup link`"
+                  "$comment": "Empty schema allows for custom rustup toolchains, specific nightlies, etc."
                 }
               ],
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/concepts/channels.html"
+                },
+                "docs": {
+                  "main": "Rust is released to three different \"channels\": stable, beta,\nand nightly."
                 }
               }
             },
             "components": {
-              "description": "Components to be added when installing the toolchain.",
+              "description": "Components to be installed as part of the toolchain.",
               "type": "array",
               "items": {
                 "type": "string",
@@ -62,23 +64,22 @@
                       "llvm-tools-preview",
                       "rustc-dev"
                     ],
-                    "$comment": "TODO: enumValues docs",
                     "x-taplo": {
                       "docs": {
                         "enumValues": [
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null
+                          "The Rust compiler and [Rustdoc].\n[rustdoc]: https://doc.rust-lang.org/rustdoc/",
+                          "[Cargo] is a package manager and build tool.\n\n[cargo]: https://doc.rust-lang.org/cargo/",
+                          "[Rustfmt] is a tool for automatically formatting code.\n\n[rustfmt]: https://github.com/rust-lang/rustfmt",
+                          "This is the Rust [standard library]. There is a separate\n  `rust-std` component for each target that `rustc` supports, such as\n  `rust-std-x86_64-pc-windows-msvc`. See the [Cross-compilation] chapter for\n  more detail.\n\n[standard library]: https://doc.rust-lang.org/std/\n[cross-compilation]: .https://rust-lang.github.io/rustup/cross-compilation.html",
+                          "This is a local copy of the [Rust documentation]. Use the\n  `rustup doc` command to open the documentation in a web browser. Run `rustup\n  doc --help` for more options.\n\n[rust documentation]: https://doc.rust-lang.org/",
+                          "[RLS] is a language server that provides support for editors and\n  IDEs.\n\n[RLS]: https://github.com/rust-lang/rls",
+                          "[Clippy] is a lint tool that provides extra checks for common\n  mistakes and stylistic choices.\n\n[clippy]: https://github.com/rust-lang/rust-clippy",
+                          "[Miri] is an experimental Rust interpreter, which can be used for\n  checking for undefined-behavior.\n\n[miri]: https://github.com/rust-lang/miri/",
+                          "This is a local copy of the source code of the Rust standard\n  library. This can be used by some tools, such as [RLS], to provide\n  auto-completion for functions within the standard library; [Miri] which is a\n  Rust interpreter; and Cargo's experimental [build-std] feature, which allows\n  you to rebuild the standard library locally.\n\n[RLS]: https://github.com/rust-lang/rls\n[miri]: https://github.com/rust-lang/miri/\n[build-std]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std",
+                          "Metadata about the standard library, used by tools like\n  [RLS].\n\n[RLS]: https://github.com/rust-lang/rls",
+                          "This contains a linker and platform libraries for building on\n  the `x86_64-pc-windows-gnu` platform.",
+                          "This is an experimental component which contains a\n  collection of [LLVM] tools.\n\n[LLVM]: https://llvm.org/",
+                          "This component contains the compiler as a library. Most users\n  will not need this; it is only needed for development *of* tools that link\n  to the compiler, such as making modifications to [Clippy].\n\n[clippy]: https://github.com/rust-lang/rust-clippy"
                         ]
                       }
                     }
@@ -91,6 +92,9 @@
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/concepts/components.html"
+                },
+                "docs": {
+                  "main": "Each release of Rust includes several \"components\", some of\nwhich are required (like `rustc`) and some that are optional (like\n[`clippy`])."
                 }
               }
             },
@@ -290,6 +294,9 @@
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/cross-compilation.html"
+                },
+                "docs": {
+                  "main": "`rustc` is capable of generating code for many platforms. The\n\"target\" specifies the platform that the code will be generated for. By\ndefault, `cargo` and `rustc` use the host toolchain's platform as the\ntarget. To build for a different target, usually the target's standard\nlibrary needs to be installed first via the `rustup target` command."
                 }
               }
             },
@@ -297,7 +304,6 @@
               "description": "The set of components to install when installing the toolchain.",
               "type": "string",
               "default": "default",
-              "$comment": "TODO add docs for enumValues",
               "enum": [
                 "minimal",
                 "default",
@@ -306,6 +312,14 @@
               "x-taplo": {
                 "links": {
                   "key": "https://rust-lang.github.io/rustup/concepts/profiles.html"
+                },
+                "docs": {
+                  "main": "In order to make it easier to work with components, a\n\"profile\" defines a grouping of components.",
+                  "enumValues": [
+                    "This profile includes as few components as possible to get a\nworking compiler (`rustc`, `rust-std`, and `cargo`). It's recommended to use\nthis component on Windows systems if you don't use local documentation (the\nlarge number of files can cause issues with some Antivirus systems), and in\nCI.",
+                    "This profile includes all of components in the **minimal**\nprofile, and adds `rust-docs`, `rustfmt`, and `clippy`. This profile will be\nused by `rustup` by default, and it's the one recommended for general use.",
+                    "This profile includes all the components available through\n`rustup`. This should never be used, as it includes *every* component ever\nincluded in the metadata and thus will almost always fail. If you are\nlooking for a way to install devtools such as `miri` or IDE integration\ntools (`rls`), you should use the `default` profile and\ninstall the needed additional components manually, either by using `rustup\ncomponent add` or by using `-c` when installing the toolchain."
+                  ]
                 }
               }
             }
@@ -318,7 +332,12 @@
           "properties": {
             "path": {
               "type": "string",
-              "description": "Path to a custom local toolchain. Relative paths are resolved relative to the location of the `rust-toolchain.toml` file."
+              "description": "Path to a custom local toolchain.",
+              "x-taplo": {
+                "docs": {
+                  "main": "Path to a custom local toolchain. Since a `path` directive directly names a local toolchain, other options\nlike `components`, `targets`, and `profile` have no effect. `channel`\nand `path` are mutually exclusive, since a `path` already points to a\nspecific toolchain. A relative `path` is resolved relative to the\nlocation of the `rust-toolchain.toml` file."
+                }
+              }
             }
           },
           "required": [
@@ -332,7 +351,10 @@
         },
         "initKeys": [
           "channel"
-        ]
+        ],
+        "docs": {
+          "main": "A \"toolchain\" is a complete installation of the Rust\ncompiler (`rustc`) and related tools (like `cargo`). A toolchain\nspecification includes the release channel or version, and the host\nplatform that the toolchain runs on."
+        }
       }
     }
   },

--- a/schemas/rust-toolchain.toml.json
+++ b/schemas/rust-toolchain.toml.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Schema for rust-toolchain.toml",
+  "description": "https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file",
+  "x-taplo-info": {
+    "authors": [
+      "ian-h-chamberlain (https://github.com/ian-h-chamberlain)"
+    ],
+    "patterns": [
+      "^(.*(/|\\\\)rust-toolchain([.]toml)?)$"
+    ]
+  },
+  "properties": {
+    "toolchain": {
+      "description": "Details about the Rust toolchain to be used.",
+      "type": "object",
+      "minProperties": 1,
+      "oneOf": [
+        {
+          "properties": {
+            "channel": {
+              "description": "The release channel of Rust to use.",
+              "type": "string",
+              "oneOf": [
+                {
+                  "enum": [
+                    "stable",
+                    "beta",
+                    "nightly"
+                  ],
+                  "$comment": "TODO: enumValues docs? or maybe not"
+                },
+                {
+                  "$comment": "Empty schema allows for custom rustup toolchains with `rustup link`"
+                }
+              ],
+              "x-taplo": {
+                "links": {
+                  "key": "https://rust-lang.github.io/rustup/concepts/channels.html"
+                }
+              }
+            },
+            "components": {
+              "description": "Components to be added when installing the toolchain.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "rustc",
+                      "cargo",
+                      "rustfmt",
+                      "rust-std",
+                      "rust-docs",
+                      "rls",
+                      "clippy",
+                      "miri",
+                      "rust-src",
+                      "rust-analysis",
+                      "rust-mingw",
+                      "llvm-tools-preview",
+                      "rustc-dev"
+                    ],
+                    "$comment": "TODO: enumValues docs",
+                    "x-taplo": {
+                      "docs": {
+                        "enumValues": [
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "$comment": "Empty schema to allow for forward compatibility of new components"
+                  }
+                ]
+              },
+              "x-taplo": {
+                "links": {
+                  "key": "https://rust-lang.github.io/rustup/concepts/components.html"
+                }
+              }
+            },
+            "targets": {
+              "description": "Additional platforms to install the toolchain for.",
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$comment": "Allow arbitary strings for new targets or custom target JSON",
+                    "type": "string"
+                  },
+                  {
+                    "$comment": "From `rustc +nightly --print target-list`",
+                    "enum": [
+                      "aarch64-apple-darwin",
+                      "aarch64-apple-ios",
+                      "aarch64-apple-ios-macabi",
+                      "aarch64-apple-ios-sim",
+                      "aarch64-apple-tvos",
+                      "aarch64-fuchsia",
+                      "aarch64-kmc-solid_asp3",
+                      "aarch64-linux-android",
+                      "aarch64-pc-windows-msvc",
+                      "aarch64-unknown-freebsd",
+                      "aarch64-unknown-hermit",
+                      "aarch64-unknown-linux-gnu",
+                      "aarch64-unknown-linux-gnu_ilp32",
+                      "aarch64-unknown-linux-musl",
+                      "aarch64-unknown-netbsd",
+                      "aarch64-unknown-none",
+                      "aarch64-unknown-none-softfloat",
+                      "aarch64-unknown-openbsd",
+                      "aarch64-unknown-redox",
+                      "aarch64-unknown-uefi",
+                      "aarch64-uwp-windows-msvc",
+                      "aarch64-wrs-vxworks",
+                      "aarch64_be-unknown-linux-gnu",
+                      "aarch64_be-unknown-linux-gnu_ilp32",
+                      "arm-linux-androideabi",
+                      "arm-unknown-linux-gnueabi",
+                      "arm-unknown-linux-gnueabihf",
+                      "arm-unknown-linux-musleabi",
+                      "arm-unknown-linux-musleabihf",
+                      "armebv7r-none-eabi",
+                      "armebv7r-none-eabihf",
+                      "armv4t-unknown-linux-gnueabi",
+                      "armv5te-unknown-linux-gnueabi",
+                      "armv5te-unknown-linux-musleabi",
+                      "armv5te-unknown-linux-uclibceabi",
+                      "armv6-unknown-freebsd",
+                      "armv6-unknown-netbsd-eabihf",
+                      "armv6k-nintendo-3ds",
+                      "armv7-apple-ios",
+                      "armv7-linux-androideabi",
+                      "armv7-unknown-freebsd",
+                      "armv7-unknown-linux-gnueabi",
+                      "armv7-unknown-linux-gnueabihf",
+                      "armv7-unknown-linux-musleabi",
+                      "armv7-unknown-linux-musleabihf",
+                      "armv7-unknown-linux-uclibceabihf",
+                      "armv7-unknown-netbsd-eabihf",
+                      "armv7-wrs-vxworks-eabihf",
+                      "armv7a-kmc-solid_asp3-eabi",
+                      "armv7a-kmc-solid_asp3-eabihf",
+                      "armv7a-none-eabi",
+                      "armv7a-none-eabihf",
+                      "armv7r-none-eabi",
+                      "armv7r-none-eabihf",
+                      "armv7s-apple-ios",
+                      "asmjs-unknown-emscripten",
+                      "avr-unknown-gnu-atmega328",
+                      "bpfeb-unknown-none",
+                      "bpfel-unknown-none",
+                      "hexagon-unknown-linux-musl",
+                      "i386-apple-ios",
+                      "i586-pc-windows-msvc",
+                      "i586-unknown-linux-gnu",
+                      "i586-unknown-linux-musl",
+                      "i686-apple-darwin",
+                      "i686-linux-android",
+                      "i686-pc-windows-gnu",
+                      "i686-pc-windows-msvc",
+                      "i686-unknown-freebsd",
+                      "i686-unknown-haiku",
+                      "i686-unknown-linux-gnu",
+                      "i686-unknown-linux-musl",
+                      "i686-unknown-netbsd",
+                      "i686-unknown-openbsd",
+                      "i686-unknown-uefi",
+                      "i686-uwp-windows-gnu",
+                      "i686-uwp-windows-msvc",
+                      "i686-wrs-vxworks",
+                      "m68k-unknown-linux-gnu",
+                      "mips-unknown-linux-gnu",
+                      "mips-unknown-linux-musl",
+                      "mips-unknown-linux-uclibc",
+                      "mips64-unknown-linux-gnuabi64",
+                      "mips64-unknown-linux-muslabi64",
+                      "mips64el-unknown-linux-gnuabi64",
+                      "mips64el-unknown-linux-muslabi64",
+                      "mipsel-sony-psp",
+                      "mipsel-unknown-linux-gnu",
+                      "mipsel-unknown-linux-musl",
+                      "mipsel-unknown-linux-uclibc",
+                      "mipsel-unknown-none",
+                      "mipsisa32r6-unknown-linux-gnu",
+                      "mipsisa32r6el-unknown-linux-gnu",
+                      "mipsisa64r6-unknown-linux-gnuabi64",
+                      "mipsisa64r6el-unknown-linux-gnuabi64",
+                      "msp430-none-elf",
+                      "nvptx64-nvidia-cuda",
+                      "powerpc-unknown-freebsd",
+                      "powerpc-unknown-linux-gnu",
+                      "powerpc-unknown-linux-gnuspe",
+                      "powerpc-unknown-linux-musl",
+                      "powerpc-unknown-netbsd",
+                      "powerpc-unknown-openbsd",
+                      "powerpc-wrs-vxworks",
+                      "powerpc-wrs-vxworks-spe",
+                      "powerpc64-unknown-freebsd",
+                      "powerpc64-unknown-linux-gnu",
+                      "powerpc64-unknown-linux-musl",
+                      "powerpc64-wrs-vxworks",
+                      "powerpc64le-unknown-freebsd",
+                      "powerpc64le-unknown-linux-gnu",
+                      "powerpc64le-unknown-linux-musl",
+                      "riscv32gc-unknown-linux-gnu",
+                      "riscv32gc-unknown-linux-musl",
+                      "riscv32i-unknown-none-elf",
+                      "riscv32imac-unknown-none-elf",
+                      "riscv32imc-esp-espidf",
+                      "riscv32imc-unknown-none-elf",
+                      "riscv64gc-unknown-freebsd",
+                      "riscv64gc-unknown-linux-gnu",
+                      "riscv64gc-unknown-linux-musl",
+                      "riscv64gc-unknown-none-elf",
+                      "riscv64imac-unknown-none-elf",
+                      "s390x-unknown-linux-gnu",
+                      "s390x-unknown-linux-musl",
+                      "sparc-unknown-linux-gnu",
+                      "sparc64-unknown-linux-gnu",
+                      "sparc64-unknown-netbsd",
+                      "sparc64-unknown-openbsd",
+                      "sparcv9-sun-solaris",
+                      "thumbv4t-none-eabi",
+                      "thumbv6m-none-eabi",
+                      "thumbv7a-pc-windows-msvc",
+                      "thumbv7a-uwp-windows-msvc",
+                      "thumbv7em-none-eabi",
+                      "thumbv7em-none-eabihf",
+                      "thumbv7m-none-eabi",
+                      "thumbv7neon-linux-androideabi",
+                      "thumbv7neon-unknown-linux-gnueabihf",
+                      "thumbv7neon-unknown-linux-musleabihf",
+                      "thumbv8m.base-none-eabi",
+                      "thumbv8m.main-none-eabi",
+                      "thumbv8m.main-none-eabihf",
+                      "wasm32-unknown-emscripten",
+                      "wasm32-unknown-unknown",
+                      "wasm32-wasi",
+                      "wasm64-unknown-unknown",
+                      "x86_64-apple-darwin",
+                      "x86_64-apple-ios",
+                      "x86_64-apple-ios-macabi",
+                      "x86_64-apple-tvos",
+                      "x86_64-fortanix-unknown-sgx",
+                      "x86_64-fuchsia",
+                      "x86_64-linux-android",
+                      "x86_64-pc-solaris",
+                      "x86_64-pc-windows-gnu",
+                      "x86_64-pc-windows-msvc",
+                      "x86_64-sun-solaris",
+                      "x86_64-unknown-dragonfly",
+                      "x86_64-unknown-freebsd",
+                      "x86_64-unknown-haiku",
+                      "x86_64-unknown-hermit",
+                      "x86_64-unknown-illumos",
+                      "x86_64-unknown-l4re-uclibc",
+                      "x86_64-unknown-linux-gnu",
+                      "x86_64-unknown-linux-gnux32",
+                      "x86_64-unknown-linux-musl",
+                      "x86_64-unknown-netbsd",
+                      "x86_64-unknown-none",
+                      "x86_64-unknown-none-hermitkernel",
+                      "x86_64-unknown-none-linuxkernel",
+                      "x86_64-unknown-openbsd",
+                      "x86_64-unknown-redox",
+                      "x86_64-unknown-uefi",
+                      "x86_64-uwp-windows-gnu",
+                      "x86_64-uwp-windows-msvc",
+                      "x86_64-wrs-vxworks"
+                    ]
+                  }
+                ]
+              },
+              "x-taplo": {
+                "links": {
+                  "key": "https://rust-lang.github.io/rustup/cross-compilation.html"
+                }
+              }
+            },
+            "profile": {
+              "description": "The set of components to install when installing the toolchain.",
+              "type": "string",
+              "default": "default",
+              "$comment": "TODO add docs for enumValues",
+              "enum": [
+                "minimal",
+                "default",
+                "complete"
+              ],
+              "x-taplo": {
+                "links": {
+                  "key": "https://rust-lang.github.io/rustup/concepts/profiles.html"
+                }
+              }
+            }
+          },
+          "required": [
+            "channel"
+          ]
+        },
+        {
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Path to a custom local toolchain. Relative paths are resolved relative to the location of the `rust-toolchain.toml` file."
+            }
+          },
+          "required": [
+            "path"
+          ]
+        }
+      ],
+      "x-taplo": {
+        "links": {
+          "key": "https://rust-lang.github.io/rustup/concepts/toolchains.html"
+        },
+        "initKeys": [
+          "channel"
+        ]
+      }
+    }
+  },
+  "required": [
+    "toolchain"
+  ]
+}


### PR DESCRIPTION
First part of #228.

I am hoping to get to `.cargo/config.toml` next, but it has _lots_ of fields so may take a bit longer.

Please let me know if there's anything you'd like added or changed, I think I got most of the docs (pulled from [the rustup book](https://rust-lang.github.io/rustup/index.html)), but may have overlooked or typoed something. 