### PR TITLE
Fix jsonschema compile error

### DIFF
--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -19,7 +19,7 @@ glob = "0.3.0"
 globset = "0.4.8"
 hex = "0.4.3"
 indexmap = { version = "1.8.0", features = ["serde", "rayon"] }
-jsonschema = { version = "0.15.0", default-features = false }
+jsonschema = { version = "0.15.2", default-features = false, features = ["resolve-http"] }
 lru = "0.7.2"
 parking_lot = "0.12.0"
 regex = "1.5.4"


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

command:

```bash
// v0.6.1
cargo install taplo-cli
```

compile error:

```log
   Compiling jsonschema v0.15.2
error: the `reqwest` feature alone does not enable HTTP schema resolving anymore.
       Use the `resolve-http` feature which enables `native-tls` as well;
       or both `reqwest` and `rustls` features together, if you prefer rustls.
  --> /home/koushiro/.cargo/registry/src/github.com-1ecc6299db9ec823/jsonschema-0.15.2/src/resolver.rs:85:21
   |
85 | /                     compile_error!(
86 | |                         r#"the `reqwest` feature alone does not enable HTTP schema resolving anymore.
87 | | Use the `resolve-http` feature which enables `native-tls` as well;
88 | | or both `reqwest` and `rustls` features together, if you prefer rustls."#
89 | |                     );
   | |_____________________^

error: could not compile `jsonschema` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```