### PR TITLE
Add `--stdin-filepath` option to format cmd

### DIFF
--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -96,6 +96,13 @@ pub struct FormatCommand {
     ///
     /// If the only argument is "-", the standard input will be used.
     pub files: Vec<String>,
+
+    /// A path to the file that the Taplo CLI will treat like stdin.
+    ///
+    /// This option does not change the file input source. This option should be used only when the
+    /// source input arises from the stdin.
+    #[clap(long)]
+    pub stdin_filepath: Option<String>,
 }
 
 #[cfg(feature = "lsp")]


### PR DESCRIPTION
This PR introduces the `--stdin-filepath` option to the `format` command.

This was inspired by ESLint's `--stdin-filename` and Prettier's [`--stdin-filepath`](https://prettier.io/docs/en/cli.html#--stdin-filepath). It doesn't have any behavior in the actual parsing of files or their resolution.

It is mainly useful when showing error information. In such cases, instead of getting:

```txt
  ┌─ -:2:5
  │
2 │ [bar=6
  │     ^ expected "]"
```

One would get:

```txt
  ┌─ ./foo.toml:2:5
  │
2 │ [bar=6
  │     ^ expected "]"
```
By executing `format` as `taplo format --stdin-filepath ./foo.toml -`.