### PR TITLE
pyproject.toml.json to match poetry author regex

### DIFF
--- a/schemas/pyproject.toml.json
+++ b/schemas/pyproject.toml.json
@@ -9,7 +9,7 @@
     "poetry-author-pattern": {
       "description": "Pattern that matches `Name <email>` like 'King Arthur' or 'Miss Islington &lt;miss-islington@python.org&gt;'.",
       "type": "string",
-      "pattern": "^(?:\\S+?\\s)+?(?:<(?:[a-z\\d!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z\\d!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z\\d](?:[a-z\\d-]*[a-z\\d])?\\.)+[a-z\\d](?:[a-z\\d-]*[a-z\\d])?|\\[(?:(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?)\\.){3}(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?|[a-z\\d-]*[a-z\\d]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])>)?$"
+      "pattern": "^[- .,\w\d'’\"()&]+(?: <.+?>)?$"
     },
     "poetry-authors": {
       "type": "array",


### PR DESCRIPTION
Using the same regex used by Poetry, with the named capturing groups removed. Main difference is that the email in poetry is optional.

Poetry defines its AUTHOR_REGEX here:
https://github.com/python-poetry/poetry-core/blob/cd444099391eaf237fbe2aea0e82f5e296f06b1b/src/poetry/core/packages/package.py#L33