### PR TITLE
add delta view to taplo-cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,28 @@
 [workspace]
 members = ["crates/*"]
-exclude = ["util/test-gen", "crates/taplo-wasm"]
+  exclude = ["util/test-gen", "crates/taplo-wasm"]
 
 [profile.release]
 codegen-units = 1
-lto = "thin"
-opt-level = 3
+      opt-level = 3
+lto           = "thin"
 strip = "debuginfo"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 [profile.bench]
 lto = true
-opt-level = 3
+         opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,14 @@
 [workspace]
 members = ["crates/*"]
-  exclude = ["util/test-gen", "crates/taplo-wasm"]
+exclude = ["util/test-gen", "crates/taplo-wasm"]
 
 [profile.release]
 codegen-units = 1
-      opt-level = 3
-lto           = "thin"
+opt-level = 3
+lto = "thin"
 strip = "debuginfo"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 [profile.bench]
 lto = true
-         opt-level = 3
+opt-level = 3

--- a/crates/lsp-async-stub/Cargo.toml
+++ b/crates/lsp-async-stub/Cargo.toml
@@ -23,11 +23,11 @@ tracing = "0.1.29"
 [features]
 default = []
 tokio-stdio = [
-    "tokio",
-    "tokio/rt",
-    "tokio/io-util",
-    "tokio/io-std",
-    "tokio/macros",
+  "tokio",
+  "tokio/rt",
+  "tokio/io-util",
+  "tokio/io-std",
+  "tokio/macros",
 ]
 tokio-tcp = ["tokio", "tokio/rt", "tokio/io-util", "tokio/net", "tokio/macros"]
 

--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -38,6 +38,8 @@ toml = "0.5"
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2.2"
+prettydiff = "0.6.1"
+ansi_term = "0.12"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 atty = "0.2.14"

--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -16,6 +16,7 @@ lsp = ["taplo-lsp", "async-ctrlc"]
 toml-test = []
 
 [dependencies]
+ansi_term = "0.12"
 anyhow = { version = "1", features = ["backtrace"] }
 async-ctrlc = { version = "1.2.0", features = ["stream"], optional = true }
 clap = { version = "3.0.0", features = ["derive", "cargo"] }
@@ -25,6 +26,7 @@ glob = "0.3"
 hex = "0.4"
 itertools = "0.10.3"
 once_cell = "1.4"
+prettydiff = "0.6.1"
 regex = "1.4"
 reqwest = { version = "0.11.9", default-features = false, features = ["json", "rustls-tls"] }
 schemars = "0.8"
@@ -38,22 +40,20 @@ toml = "0.5"
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2.2"
-prettydiff = "0.6.1"
-ansi_term = "0.12"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 atty = "0.2.14"
 tokio = { version = "1.19.2", features = [
-    "sync",
-    "fs",
-    "time",
-    "io-std",
-    "rt-multi-thread",
-    "parking_lot",
+  "sync",
+  "fs",
+  "time",
+  "io-std",
+  "rt-multi-thread",
+  "parking_lot",
 ] }
 lsp-async-stub = { version = "0.6.0", path = "../lsp-async-stub", features = [
-    "tokio-tcp",
-    "tokio-stdio",
+  "tokio-tcp",
+  "tokio-stdio",
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -91,6 +91,10 @@ pub struct FormatCommand {
     #[clap(long)]
     pub check: bool,
 
+    /// Print the differences in patch formatting to `stdout`
+    #[clap(long)]
+    pub diff: bool,
+
     /// Paths or glob patterns to TOML documents.
     ///
     /// If the only argument is "-", the standard input will be used.

--- a/crates/taplo-cli/src/commands/format.rs
+++ b/crates/taplo-cli/src/commands/format.rs
@@ -66,11 +66,19 @@ impl<E: Environment> Taplo<E> {
         Ok(())
     }
 
-    fn print_diff(path: impl AsRef<Path>, original: &str, formatted: &str) {
+    async fn print_diff(&self, path: impl AsRef<Path>, original: &str, formatted: &str) {
         let path = path.as_ref();
-        println!("diff a/{path} b/{path}", path = path.display());
-        println!("--- a/{path}", path = path.display());
-        println!("+++ b/{path}", path = path.display());
+
+        // print to stdout
+        macro_rules! echo {
+            ($($args:tt)*) => {
+                self.env.stdout().write_all_buf(&mut &std::format_args!($($args)*));
+                self.env.stdout().write_all_buf(&mut "\n");
+            }
+        }
+        echo!("diff a/{path} b/{path}", path = path.display());
+        echo!("--- a/{path}", path = path.display());
+        echo!("+++ b/{path}", path = path.display());
 
         // How many lines of context to print:
         const CONTEXT_LINES: usize = 7;
@@ -140,14 +148,14 @@ impl<E: Environment> Taplo<E> {
                     post_length += ins.len();
                 }
             };
-            println!(
+            echo!(
                 "@@ -{},{} +{},{} @@",
                 pre_line, pre_length, post_line, post_length
             );
+            echo!("{}", acc.join("\n"));
 
             pre_line += pre_length;
             post_line += post_length;
-            println!("{}", acc.join("\n"));
             acc.clear();
         }
     }

--- a/crates/taplo-cli/src/commands/format.rs
+++ b/crates/taplo-cli/src/commands/format.rs
@@ -147,8 +147,6 @@ impl<E: Environment> Taplo<E> {
 
             pre_line += pre_length;
             post_line += post_length;
-            post_length = 0;
-            pre_length = 0;
             println!("{}", acc.join("\n"));
             acc.clear();
         }

--- a/crates/taplo-cli/src/commands/format.rs
+++ b/crates/taplo-cli/src/commands/format.rs
@@ -157,7 +157,10 @@ impl<E: Environment> Taplo<E> {
             };
             echo!(
                 "@@ -{},{} +{},{} @@",
-                pre_line, pre_length, post_line, post_length
+                pre_line,
+                pre_length,
+                post_line,
+                post_length
             );
             echo!("{}", acc.join("\n"));
 

--- a/crates/taplo-cli/src/commands/format.rs
+++ b/crates/taplo-cli/src/commands/format.rs
@@ -215,11 +215,12 @@ impl<E: Environment> Taplo<E> {
             .map_err(|err| anyhow!("invalid key pattern: {err}"))?;
 
             if source != formatted {
+                if cmd.diff {
+                    self.print_diff(path, &source, &formatted);
+                }
+
                 if cmd.check {
                     tracing::error!(?path, "the file is not properly formatted");
-
-                    Self::print_diff(path, &source, &formatted);
-
                     result = Err(anyhow!("some files were not properly formatted"));
                 } else {
                     self.env.write_file(&path, formatted.as_bytes()).await?;

--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -42,11 +42,11 @@ url = { version = "2.2.2", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.19.2", features = [
-    "sync",
-    "fs",
-    "time",
-    "io-std",
-    "parking_lot",
+  "sync",
+  "fs",
+  "time",
+  "io-std",
+  "parking_lot",
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/taplo-wasm/Cargo.toml
+++ b/crates/taplo-wasm/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.56"
 clap = { version = "3.1.18", features = ["derive"] }
 console_error_panic_hook = "0.1.7"
 futures = "0.3.21"
+indexmap = "~1.6"
 js-sys = "0.3.57"
 lsp-async-stub = { path = "../lsp-async-stub" }
 serde = { version = "1.0.137", features = ["derive"] }
@@ -29,7 +30,6 @@ tracing = "0.1.35"
 url = "2.2.2"
 wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.30"
-indexmap = "~1.6"
 
 [features]
 default = ["lsp", "cli"]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,5 +1,10 @@
 include = ["**/*.toml"]
-exclude = ["**/*nested-1000.toml", "**/node_modules/**", "**/invalid/*", "test-data/analytics/**"]
+exclude = [
+  "**/*nested-1000.toml",
+  "**/node_modules/**",
+  "**/invalid/*",
+  "test-data/analytics/**",
+]
 
 [[rule]]
 include = ["**/Cargo.toml"]


### PR DESCRIPTION
It's not uncommon to use a formatter in CI where a subset of contributors do not have the tool installed. That set of contributors is usually very appreciative of direct cues what to fix.

The changes:

Adds a dependency to `prettydiff` and `ansi_term` for creating the diff and coloring, there is currently (almost) no clustering of diff lines, this is to be improved.