### PR TITLE
drop the openssl dependency

### DIFF
--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4"
 itertools = "0.10.3"
 once_cell = "1.4"
 regex = "1.4"
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.9", default-features = false, features = ["json", "rustls-tls"] }
 schemars = "0.8"
 serde = "1"
 serde_json = "1"

--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -26,7 +26,7 @@ lru = "0.7.2"
 parking_lot = "0.12.0"
 percent-encoding = "2.1.0"
 regex = "1.5.4"
-reqwest = { version = "0.11.9", features = ["json"] }
+reqwest = { version = "0.11.9", default-features = false, features = ["json", "rustls-tls"] }
 schemars = { version = "0.8.8", features = ["url"] }
 semver = { version = "1.0.5", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/taplo-lsp/Cargo.toml
+++ b/crates/taplo-lsp/Cargo.toml
@@ -27,7 +27,7 @@ lsp-types = { version = "0.93.0", features = ["proposed"] }
 once_cell = "1.5"
 parking_lot = "0.12.0"
 regex = "1.5.4"
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.9", default-features = false, features = ["json", "rustls-tls"] }
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
Removes the dependency on openssl by using the `rustls-tls` feature flags across all toplo packages.