### PR TITLE
fix(cli): remove build script

### DIFF
--- a/crates/taplo-cli/build.rs
+++ b/crates/taplo-cli/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    println!(
-        "cargo:rustc-env=BUILD_TARGET={}",
-        std::env::var("TARGET").unwrap()
-    );
-}


### PR DESCRIPTION
This env's use was removed in #211, so the build script is unnecessary.