### PR TITLE
feat: reorder_arrays flag

### DIFF
--- a/crates/taplo/src/tests/formatter.rs
+++ b/crates/taplo/src/tests/formatter.rs
@@ -971,3 +971,56 @@ very_long_inline_table = { array = ["aaaaa", "aaaaa", "aaaaa", "aaaaa", "aaaaa",
 
     assert_format!(src, &formatted);
 }
+
+#[test]
+fn test_sorted_groupings_in_array() {
+    let src = r#"
+foo = [
+  "b",
+  "a",
+  "c",
+
+  2021-01-01,
+  1979-05-27,
+
+  ["x", "a"],
+  { b = 2, a = 1 },
+
+  3,
+  1,
+  2,
+  10, # due to the lexicographic order
+  3
+]
+"#;
+
+    let expected = r#"
+foo = [
+  "a",
+  "b",
+  "c",
+
+  1979-05-27,
+  2021-01-01,
+
+  ["a", "x"],
+  { b = 2, a = 1 },
+
+  1,
+  10, # due to the lexicographic order
+  2,
+  3,
+  3,
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            reorder_arrays: true,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -365,6 +365,12 @@
           "default": null,
           "description": "Alphabetically reorder keys that are not separated by blank lines."
         },
+        "evenBetterToml.formatter.reorderArrays": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": null,
+          "description": "Alphabetically reorder array values that are not separated by blank lines."
+        },
         "evenBetterToml.formatter.allowedBlankLines": {
           "scope": "resource",
           "type": "number",

--- a/site/site/configuration/formatter-options.md
+++ b/site/site/configuration/formatter-options.md
@@ -25,5 +25,6 @@ In some environments (e.g. in Visual Studio Code and JavaScript) the option keys
 |     indent_string     |                        Indentation to use, should be tabs or spaces but technically could be anything.                         | 2 spaces (" ") |
 |   trailing_newline    |                                              Add trailing newline to the source.                                               |      true      |
 |     reorder_keys      |                               Alphabetically reorder keys that are not separated by blank lines.                               |     false      |
+|    reorder_arrays     |                           Alphabetically reorder array values that are not separated by blank lines.                           |     false      |
 |  allowed_blank_lines  |                                     The maximum amount of consecutive blank lines allowed.                                     |       2        |
 |         crlf          |                                                     Use CRLF line endings.                                                     |     false      |


### PR DESCRIPTION
A fix for #338 and #158 issues.

- [x] sort groupings
- [x]     add an option for it in the formatter options
- [x]     add tests for it
- [x]     documentation on the website
- [x]     add a vscode extension setting in package.json
