### PR TITLE
Add code snippet in vscode page to enable autoformatting

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -105,6 +105,16 @@ Works even for tables not in order.
 
 ## Formatting
 
+To enable automatic formatting, add the following to your `settings.json` file.
+
+```json
+{
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml"
+  }
+}
+```
+
 The formatter is rather conservative by default, additional features can be enabled in the settings. If you're missing a configuration option, feel free to open an issue about it!
 
 ![Formatting](images/formatting.gif)


### PR DESCRIPTION
## What

Add a small snippet in the `formatting` entry in the vscode page to accommodate easy adoption for new vscode users like me.