### PR TITLE
Handle LSP shutdown request

### DIFF
--- a/crates/lsp-async-stub/src/listen.rs
+++ b/crates/lsp-async-stub/src/listen.rs
@@ -64,8 +64,6 @@ impl<W: Clone + 'static> Server<W> {
                                     drop(output);
                                     drop(input);
                                     break;
-                                } else if msg.method.as_ref().map(|m| m == "shutdown").unwrap_or(false) {
-                                    continue;
                                 }
 
                                 let task_fut = self.handle_message(


### PR DESCRIPTION
These lines in the Server loop discard any messages with the shutdown method. The Server can handle and correctly respond to shutdown requests, though, so there's no need to discard the message.