### PR TITLE
docs(cli): fix binary download links

### DIFF
--- a/site/site/cli/installation/binary.md
+++ b/site/site/cli/installation/binary.md
@@ -12,8 +12,8 @@ The default build with commonly-used features.
 
 #### Download
 
-- [Linux (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-x86_64-unknown-linux-gnu.tar.gz)
-- [macOS (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-x86_64-apple-darwin-gnu.tar.gz)
+- [Linux (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz)
+- [macOS (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-darwin-x86_64.gz)
 - Windows coming soon...
 
 ### Full Build
@@ -25,6 +25,13 @@ The full build contains the following additional features:
 
 #### Download
 
-- [Linux (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-x86_64-unknown-linux-gnu.tar.gz)
-- [macOS (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-x86_64-apple-darwin-gnu.tar.gz)
+- [Linux (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz)
+- [macOS (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-darwin-x86_64.gz)
 - Windows coming soon...
+
+## Example
+
+```bash
+curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \
+  | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+```


### PR DESCRIPTION
Adjust the broken download links for the cli binaries so that they work with the latest tag.

Signed-off-by: Nico Braun <rainbowstack@gmail.com>

fix: #365 