### PR TITLE
fix: language server include rule matching

### DIFF
--- a/crates/taplo-common/src/config.rs
+++ b/crates/taplo-common/src/config.rs
@@ -108,7 +108,7 @@ impl Config {
     pub fn rules_for<'r>(
         &'r self,
         path: &'r Path,
-    ) -> impl DoubleEndedIterator<Item = &'r Rule> + 'r {
+    ) -> impl DoubleEndedIterator<Item = &'r Rule> + Clone + 'r {
         self.rule.iter().filter(|r| r.is_included(path))
     }
 
@@ -129,7 +129,7 @@ impl Config {
     pub fn format_scopes<'s>(
         &'s self,
         path: &'s Path,
-    ) -> impl Iterator<Item = (&String, taplo::formatter::OptionsIncomplete)> + 's {
+    ) -> impl Iterator<Item = (&String, taplo::formatter::OptionsIncomplete)> + Clone + 's {
         self.rules_for(path)
             .filter_map(|rule| match (&rule.keys, &rule.options.formatting) {
                 (Some(keys), Some(opts)) => Some(keys.iter().map(move |k| (k, opts.clone()))),

--- a/crates/taplo-lsp/src/handlers/formatting.rs
+++ b/crates/taplo-lsp/src/handlers/formatting.rs
@@ -50,11 +50,11 @@ pub(crate) async fn format<E: Environment>(
     ws.taplo_config
         .update_format_options(&doc_path, &mut format_opts);
 
-    let scopes = ws.taplo_config.format_scopes(&doc_path).collect::<Vec<_>>();
+    let scopes = ws.taplo_config.format_scopes(&doc_path);
     tracing::trace!(
         ?doc_path,
         ?format_opts,
-        ?scopes,
+        scopes = ?scopes.clone().collect::<Vec<_>>(),
         all_rules = ?ws.taplo_config.rule,
         matched_rules = ?ws.taplo_config.rules_for(&doc_path).collect::<Vec<_>>(),
     );


### PR DESCRIPTION
Previously, using a configuration like:

```taplo.toml
[formatting]
reorder_keys = false
align_entries = true

[[rule]]
include = ["**/taplo.toml", "**/.taplo.toml"]

[rule.formatting]
reorder_keys = true
```

Running `taplo fmt` would  sort the two formatting keys, but the language server (i.e. "format document" in vscode) would not.

The trouble is that the language server was comparing an include rule (prefixed with the absolute path of a workspace) against a file URI directly, and a GlobRule that's including
`/absolute/path/**/taplo.toml` does not match a normalized URI string like `file:///absolute/path/taplo.toml`.

Also, because of the path prefix, changing the config file to

```
include = ["file://**/taplo.toml"]
```

produces a similar result (neither `taplo fmt` nor the server apply the rule), because `file:///abs/path/taplo.toml` also does not match the glob `/abs/path/file://**/taplo.toml`.