### PR TITLE
docs: document Trunk Check integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@
 
 This is the repository for Taplo, a TOML v1.0.0 toolkit, more details on the [website](https://taplo.tamasfe.dev).
 
-
 - [Taplo](#taplo)
   - [Status](#status)
   - [Contributing](#contributing)
+
+## Integrations
+
+- [Trunk Check](https://trunk.io/products/check), a universal linter/formatter (available as a [CLI](https://docs.trunk.io/docs/initialize-trunk-in-a-git-repo), [VSCode extension](https://marketplace.visualstudio.com/items?itemName=Trunk.io), and [GitHub Action](https://github.com/trunk-io/trunk-action))
 
 ## Status
 


### PR DESCRIPTION
Trunk Check is a universal linter which integrates with a wide variety of linters and formatters, `taplo` included.

We're big fans of `taplo` and figured that you might find our tool to be interesting enough to include it here.

---

`taplo` has been super useful for us, and we've had a few users [ask us about our integration with you](https://trunkcommunity.slack.com/archives/C0205B6KK8X/p1674743406903219), so we figured that it would be nice to also add documentation from your side :)