### PR TITLE
site(schemas): Add rust-analyzer into rust-toolchain.toml

### DIFF
--- a/site/site/public/schemas/rust-toolchain.toml.json
+++ b/site/site/public/schemas/rust-toolchain.toml.json
@@ -52,6 +52,7 @@
                       "rustfmt",
                       "rust-std",
                       "rust-docs",
+                      "rust-analyzer",
                       "rls",
                       "clippy",
                       "miri",


### PR DESCRIPTION
rust-analyzer has been added in components

This PR will fix the warning of

![image](https://user-images.githubusercontent.com/5351546/235357057-1afc5419-c41d-438e-a689-899d7521c9e7.png)
