### PR TITLE
Add `align_single_comments` option

### DIFF
--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -182,6 +182,10 @@ impl Options {
     fn newlines(&self, count: usize) -> impl Iterator<Item = &'static str> {
         repeat(self.newline()).take(usize::min(count, self.allowed_blank_lines + 1))
     }
+
+    fn should_align_comments(&self, comment_count: usize) -> bool {
+        (comment_count != 1 || self.align_single_comments) && self.align_comments
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -722,8 +726,7 @@ fn add_entries(
         })
         .collect::<Vec<_>>();
 
-    let align_comments =
-        (comment_count != 1 || options.align_single_comments) && options.align_comments;
+    let align_comments = options.should_align_comments(comment_count);
     *formatted += &format_rows(
         if !options.align_entries && !align_comments {
             0..0
@@ -998,8 +1001,7 @@ fn format_array(node: SyntaxNode, options: &Options, context: &Context) -> impl 
             })
             .collect::<Vec<_>>();
 
-        let align_comments =
-            (comment_count != 1 || options.align_single_comments) && options.align_comments;
+        let align_comments = options.should_align_comments(comment_count);
         *formatted += &format_rows(
             if align_comments { 0..usize::MAX } else { 0..0 },
             1..usize::MAX,

--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -51,6 +51,10 @@ create_options!(
         /// This applies to comments that are after entries or array items.
         pub align_comments: bool,
 
+        /// If `align_comments` is true, apply the alignment in cases where
+        /// there's only one comment.
+        pub align_single_comments: bool,
+
         /// Put trailing commas for multiline
         /// arrays.
         pub array_trailing_comma: bool,
@@ -145,6 +149,7 @@ impl Default for Options {
         Options {
             align_entries: false,
             align_comments: true,
+            align_single_comments: true,
             array_trailing_comma: true,
             array_auto_expand: true,
             array_auto_collapse: true,
@@ -697,6 +702,7 @@ fn add_entries(
         }
     }
 
+    let mut comment_count = 0;
     // Transform the entries into generic rows that can be aligned.
     let rows = entry_group
         .drain(0..)
@@ -709,18 +715,21 @@ fn add_entries(
             row.push(e.value);
             if let Some(c) = e.comment {
                 row.push(c);
+                comment_count += 1;
             }
 
             row
         })
         .collect::<Vec<_>>();
 
+    let align_comments =
+        (comment_count != 1 || options.align_single_comments) && options.align_comments;
     *formatted += &format_rows(
-        if !options.align_entries && !options.align_comments {
+        if !options.align_entries && !align_comments {
             0..0
-        } else if !options.align_entries && options.align_comments {
+        } else if !options.align_entries && align_comments {
             3..usize::MAX
-        } else if options.align_entries && !options.align_comments {
+        } else if options.align_entries && !align_comments {
             0..3
         } else {
             0..usize::MAX
@@ -972,6 +981,7 @@ fn format_array(node: SyntaxNode, options: &Options, context: &Context) -> impl 
             return were_values;
         }
 
+        let mut comment_count = 0;
         let rows = value_group
             .drain(0..)
             .map(|(value, comment)| {
@@ -981,18 +991,17 @@ fn format_array(node: SyntaxNode, options: &Options, context: &Context) -> impl 
                 row.push(value);
                 if let Some(c) = comment {
                     row.push(c);
+                    comment_count += 1;
                 }
 
                 row
             })
             .collect::<Vec<_>>();
 
+        let align_comments =
+            (comment_count != 1 || options.align_single_comments) && options.align_comments;
         *formatted += &format_rows(
-            if options.align_comments {
-                0..usize::MAX
-            } else {
-                0..0
-            },
+            if align_comments { 0..usize::MAX } else { 0..0 },
             1..usize::MAX,
             &rows,
             options.newline(),

--- a/crates/taplo/src/tests/formatter.rs
+++ b/crates/taplo/src/tests/formatter.rs
@@ -1026,7 +1026,7 @@ foo = [
 }
 
 #[test]
-fn test_single_comment_alignment() {
+fn test_single_comment_no_alignment() {
     let src = r#"
 entry1 = "string"  # trailing comment
 entry2 = "longer_string"
@@ -1042,7 +1042,7 @@ my_array = [
 "#;
 
     let expected = r#"
-entry1 = "string"  # trailing comment
+entry1 = "string" # trailing comment
 entry2 = "longer_string"
 
 my_array = [
@@ -1060,6 +1060,48 @@ my_array = [
         formatter::Options {
             align_comments: true,
             align_single_comments: false,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_single_comment_alignment() {
+    let src = r#"
+entry1 = "string"  # trailing comment
+entry2 = "longer_string"
+
+my_array = [
+  #Items
+  "abc",
+  "b", # Some comment
+  "caa",
+ # comment
+  # Other stuff
+]
+"#;
+
+    let expected = r#"
+entry1 = "string"        # trailing comment
+entry2 = "longer_string"
+
+my_array = [
+  #Items
+  "abc",
+  "b",   # Some comment
+  "caa",
+  # comment
+  # Other stuff
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: true,
+            align_single_comments: true,
             ..Default::default()
         },
     );

--- a/crates/taplo/src/tests/formatter.rs
+++ b/crates/taplo/src/tests/formatter.rs
@@ -1024,3 +1024,45 @@ foo = [
 
     assert_format!(expected, &formatted);
 }
+
+#[test]
+fn test_single_comment_alignment() {
+    let src = r#"
+entry1 = "string"  # trailing comment
+entry2 = "longer_string"
+
+my_array = [
+  #Items
+  "abc",
+  "b", # Some comment
+  "caa",
+ # comment
+  # Other stuff
+]
+"#;
+
+    let expected = r#"
+entry1 = "string"  # trailing comment
+entry2 = "longer_string"
+
+my_array = [
+  #Items
+  "abc",
+  "b", # Some comment
+  "caa",
+  # comment
+  # Other stuff
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            align_comments: true,
+            align_single_comments: false,
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}


### PR DESCRIPTION
Fixes #404 by adding a new option (as to not disrupt existing behavior) that controls whether single comments get aligned.