### PR TITLE
docs: add windows builds and more architectures

### DIFF
--- a/site/site/cli/installation/binary.md
+++ b/site/site/cli/installation/binary.md
@@ -12,9 +12,13 @@ The default build with commonly-used features.
 
 #### Download
 
+- [Linux (x86)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86.gz)
 - [Linux (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz)
+- [Linux (ARM64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-aarch64.gz)
 - [macOS (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-darwin-x86_64.gz)
-- Windows coming soon...
+- [macOS (ARM64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-darwin-aarch64.gz)
+- [Windows (x86)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-windows-x86_64.zip)
+- [Windows (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-windows-x86_64.zip)
 
 ### Full Build
 
@@ -25,9 +29,13 @@ The full build contains the following additional features:
 
 #### Download
 
+- [Linux (x86)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86.gz)
 - [Linux (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz)
+- [Linux (ARM64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-aarch64.gz)
 - [macOS (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-darwin-x86_64.gz)
-- Windows coming soon...
+- [macOS (ARM64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-darwin-aarch64.gz)
+- [Windows (x86)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-windows-x86.zip)
+- [Windows (x86_64)](https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-windows-x86_64.zip)
 
 ## Example
 


### PR DESCRIPTION
Updates docs to include links for Windows builds and more architectures added in #330