### PR TITLE
taplo-cli: add ENV variable support

### DIFF
--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -20,7 +20,7 @@ toml-test = []
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 async-ctrlc = { version = "1.2.0", features = ["stream"], optional = true }
-clap = { version = "3.0.0", features = ["derive", "cargo"] }
+clap = { version = "3.0.0", features = ["derive", "cargo", "env"] }
 codespan-reporting = "0.11.1"
 futures = "0.3"
 glob = "0.3"

--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -24,7 +24,7 @@ pub struct GeneralArgs {
     /// Path to the Taplo configuration file.
     ///
     /// Configuration file can be specified in $TAPLO_CONFIG
-    #[clap(long, short)]
+    #[clap(long, short, env = "TAPLO_CONFIG")]
     pub config: Option<PathBuf>,
 
     /// Set a cache path.

--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -22,6 +22,8 @@ pub struct TaploArgs {
 #[derive(Clone, Args)]
 pub struct GeneralArgs {
     /// Path to the Taplo configuration file.
+    ///
+    /// Configuration file can be specified in $TAPLO_CONFIG
     #[clap(long, short)]
     pub config: Option<PathBuf>,
 

--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -22,8 +22,6 @@ pub struct TaploArgs {
 #[derive(Clone, Args)]
 pub struct GeneralArgs {
     /// Path to the Taplo configuration file.
-    ///
-    /// Configuration file can be specified in $TAPLO_CONFIG
     #[clap(long, short, env = "TAPLO_CONFIG")]
     pub config: Option<PathBuf>,
 

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Context};
 use args::GeneralArgs;
 use itertools::Itertools;
 use std::{
+    env,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -47,7 +48,14 @@ impl<E: Environment> Taplo<E> {
 
         if config_path.is_none() && !general.no_auto_config {
             if let Some(cwd) = self.env.cwd_normalized() {
-                config_path = self.env.find_config_file_normalized(&cwd).await
+                config_path = self.env.find_config_file_normalized(&cwd).await;
+            }
+        }
+
+        if config_path.is_none() {
+            tracing::debug!("Looking for config path in the environment variable");
+            if let Ok(path) = env::var("TAPLO_CONFIG") {
+                config_path = Some(path.into());
             }
         }
 

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Context};
 use args::GeneralArgs;
 use itertools::Itertools;
 use std::{
-    env,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -48,14 +47,7 @@ impl<E: Environment> Taplo<E> {
 
         if config_path.is_none() && !general.no_auto_config {
             if let Some(cwd) = self.env.cwd_normalized() {
-                config_path = self.env.find_config_file_normalized(&cwd).await;
-            }
-        }
-
-        if config_path.is_none() {
-            tracing::debug!("Looking for config path in the environment variable");
-            if let Ok(path) = env::var("TAPLO_CONFIG") {
-                config_path = Some(path.into());
+                config_path = self.env.find_config_file_normalized(&cwd).await
             }
         }
 

--- a/site/site/cli/usage/configuration.md
+++ b/site/site/cli/usage/configuration.md
@@ -24,3 +24,5 @@ The available log levels:
 <!-- TODO: config link -->
 
 Taplo CLI by default searches for a Taplo config file in the current working directory, this behaviour can be disabled by either supplying `--no-auto-config` or `--config <path>` flags.
+
+If a config file is not provided and no file is found in the current working directory, Taplo CLI will try to retrieve the configuration file path from the `TAPLO_CONFIG` environment variable.

--- a/site/site/cli/usage/configuration.md
+++ b/site/site/cli/usage/configuration.md
@@ -23,6 +23,4 @@ The available log levels:
 
 <!-- TODO: config link -->
 
-Taplo CLI by default searches for a Taplo config file in the current working directory, this behaviour can be disabled by either supplying `--no-auto-config` or `--config <path>` flags.
-
-If a config file is not provided and no file is found in the current working directory, Taplo CLI will try to retrieve the configuration file path from the `TAPLO_CONFIG` environment variable.
+Taplo CLI, by default, searches the current working directory for a Taplo configuration file. This behaviour can be disabled by either supplying `--no-auto-config` or `--config <path>` flags. The `TAPLO_CONFIG` environmental variable can also be used to set the configuration, but the `--config` flag will take precedence.


### PR DESCRIPTION
This pull request improves the configuration file lookup logic in taplo-cli. The changes enable the CLI to search for a configuration file in the `TAPLO_CONFIG` environment variable if no configuration file is found in the current working directory and no explicit path has been provided by the user.

Changes:

1. Added support for TAPLO_CONFIG in the `load_config` function.
2. Minor documentation updates