### PR TITLE
taplo-lsp: fix hover content.

### DIFF
--- a/crates/taplo-lsp/src/handlers/hover.rs
+++ b/crates/taplo-lsp/src/handlers/hover.rs
@@ -259,6 +259,8 @@ pub(crate) async fn hover<E: Environment>(
                         docs
                     } else if let Some(desc) = schema["description"].as_str() {
                         desc.to_string()
+                    } else if let Some(title) = schema["title"].as_str() {
+                        title.to_string()
                     } else {
                         "".to_string()
                     }


### PR DESCRIPTION
If a `title` is given to `jsonschema` without `description`, the content on hover will be empty.

For example, this ocurre for the `project` key in `pyproject.toml`.

![image](https://github.com/tamasfe/taplo/assets/47286750/70ed2ae9-2ca3-4186-afab-4f018f6058bb)
