### PR TITLE
Support adding custom CA

### DIFF
--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -5,12 +5,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use taplo_common::{
-    config::Config,
-    environment::Environment,
-    schema::Schemas,
-    util::{get_reqwest_client, Normalize},
-};
+use taplo_common::{config::Config, environment::Environment, schema::Schemas, util::Normalize};
 
 pub mod args;
 pub mod commands;
@@ -26,7 +21,8 @@ pub struct Taplo<E: Environment> {
 impl<E: Environment> Taplo<E> {
     pub fn new(env: E) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
-        let http = get_reqwest_client(std::time::Duration::from_secs(5)).unwrap();
+        let http =
+            taplo_common::util::get_reqwest_client(std::time::Duration::from_secs(5)).unwrap();
 
         #[cfg(target_arch = "wasm32")]
         let http = reqwest::Client::default();

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -5,7 +5,12 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use taplo_common::{config::Config, environment::Environment, schema::Schemas, util::Normalize};
+use taplo_common::{
+    config::Config,
+    environment::Environment,
+    schema::Schemas,
+    util::{get_reqwest_client, Normalize},
+};
 
 pub mod args;
 pub mod commands;
@@ -21,10 +26,7 @@ pub struct Taplo<E: Environment> {
 impl<E: Environment> Taplo<E> {
     pub fn new(env: E) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
-        let http = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(5))
-            .build()
-            .unwrap();
+        let http = get_reqwest_client(std::time::Duration::from_secs(5)).unwrap();
 
         #[cfg(target_arch = "wasm32")]
         let http = reqwest::Client::default();

--- a/crates/taplo-common/src/util.rs
+++ b/crates/taplo-common/src/util.rs
@@ -121,6 +121,7 @@ pub(crate) fn normalize_str(s: &str) -> Cow<str> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tracing::instrument]
 pub fn get_reqwest_client(timeout: std::time::Duration) -> Result<reqwest::Client, reqwest::Error> {
     fn get_cert(path: impl AsRef<Path>) -> Result<reqwest::Certificate, anyhow::Error> {

--- a/crates/taplo-common/src/util.rs
+++ b/crates/taplo-common/src/util.rs
@@ -123,24 +123,31 @@ pub(crate) fn normalize_str(s: &str) -> Cow<str> {
 
 #[tracing::instrument]
 pub fn get_reqwest_client(timeout: std::time::Duration) -> Result<reqwest::Client, reqwest::Error> {
-    fn get_cert() -> Result<reqwest::Certificate, anyhow::Error> {
-        let path = std::env::var("TAPLO_EXTRA_CA_CERTS")?;
-        let path = Path::new(&path);
-        let ext = path.extension().and_then(|ext| ext.to_str());
+    fn get_cert(path: impl AsRef<Path>) -> Result<reqwest::Certificate, anyhow::Error> {
+        let path = path.as_ref();
+        let is_der = path.extension().map_or(false, |ext| ext == "der");
         let buf = std::fs::read(path)?;
         tracing::info!(
             "Found a custom CA {}. Reading the CA...",
             path.to_string_lossy()
         );
-        match ext {
-            Some("der") => Ok(reqwest::Certificate::from_der(&buf)?),
-            _ => Ok(reqwest::Certificate::from_pem(&buf)?),
+        if is_der {
+            Ok(reqwest::Certificate::from_der(&buf)?)
+        } else {
+            Ok(reqwest::Certificate::from_pem(&buf)?)
         }
     }
     let mut builder = reqwest::Client::builder().timeout(timeout);
-    if let Ok(cert) = get_cert() {
-        builder = builder.add_root_certificate(cert);
-        tracing::info!("Added the custom CA");
+    if let Some(path) = std::env::var_os("TAPLO_EXTRA_CA_CERTS") {
+        match get_cert(&path) {
+            Ok(cert) => {
+                builder = builder.add_root_certificate(cert);
+                tracing::info!(?path, "Added the custom CA");
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "Could not parse the custom CA");
+            }
+        }
     }
     builder.build()
 }

--- a/crates/taplo-lsp/src/world.rs
+++ b/crates/taplo-lsp/src/world.rs
@@ -18,6 +18,7 @@ use taplo_common::{
         associations::{priority, source, AssociationRule, SchemaAssociation},
         Schemas,
     },
+    util::get_reqwest_client,
     AsyncRwLock, HashMap, IndexMap,
 };
 
@@ -124,10 +125,7 @@ impl<E: Environment> WorkspaceState<E> {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            client = reqwest::Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap();
+            client = get_reqwest_client(Duration::from_secs(10)).unwrap();
         }
 
         Self {

--- a/crates/taplo-lsp/src/world.rs
+++ b/crates/taplo-lsp/src/world.rs
@@ -18,7 +18,6 @@ use taplo_common::{
         associations::{priority, source, AssociationRule, SchemaAssociation},
         Schemas,
     },
-    util::get_reqwest_client,
     AsyncRwLock, HashMap, IndexMap,
 };
 
@@ -125,7 +124,7 @@ impl<E: Environment> WorkspaceState<E> {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            client = get_reqwest_client(Duration::from_secs(10)).unwrap();
+            client = taplo_common::util::get_reqwest_client(Duration::from_secs(10)).unwrap();
         }
 
         Self {

--- a/site/site/configuration/using-schemas.md
+++ b/site/site/configuration/using-schemas.md
@@ -9,3 +9,5 @@ JSON schemas can be assigned to TOML documents according to the following in pri
 1. default schema set in the [configuration file](./file#schema)
 1. contributed by an [extension](./developing-schemas.md#visual-studio-code-extensions) *(Visual Studio Code only)*
 1. an association based on a [schema catalog](./developing-schemas.md#publishing)
+
+Extra root CA certificate could be added by specifying with the TAPLO_EXTRA_CA_CERTS environment. The provided paths must be absolute paths. For example, `TAPLO_EXTRA_CA_CERTS=/home/taplo-user/custom-ca.pem`


### PR DESCRIPTION
Resolve #443 

Inspired by [Node.js setting](https://nodejs.org/api/cli.html#node_extra_ca_certsfile), I named the env var to be `TAPLO_EXTRA_CA_CERTS` (plural here because one file could contain many certs).

I extracted the getting `reqwest` client part as a function though I don't know exactly where the best location for this function is. I temporarily put it in `taplo-common/util.rs`.

I tested the build on my local environment described in the issue and it worked perfectly.

to: @ia0 
How should we document this?
I was thinking about making the error more obvious and adding a suggestion to let the user know they need to add the environment variable. Though I don't really know how to match the `UnknownIssuer` error from `reqwest`.