### PR TITLE
Add pnpm install methods to npm docs

### DIFF
--- a/site/site/cli/installation/npm.md
+++ b/site/site/cli/installation/npm.md
@@ -2,15 +2,19 @@
 
 The [default](./binary.md#default-build) build of Taplo is published to NPM as [`@taplo/cli`](https://www.npmjs.com/package/@taplo/cli). You will need [Node.js](https://nodejs.org/en/) (tested with 16 and up) in order to use it.
 
-This will install the `taplo` executable globally:
+## Install with npm
 
 ```sh
 npm install -g @taplo/cli
 ```
 
+## Install with Yarn
+
 ```sh
 yarn global add @taplo/cli
 ```
+
+## Install with pnpm
 
 ```sh
 pnpm install -g @taplo/cli

--- a/site/site/cli/installation/npm.md
+++ b/site/site/cli/installation/npm.md
@@ -2,26 +2,28 @@
 
 The [default](./binary.md#default-build) build of Taplo is published to NPM as [`@taplo/cli`](https://www.npmjs.com/package/@taplo/cli). You will need [Node.js](https://nodejs.org/en/) (tested with 16 and up) in order to use it.
 
-## Installation via npm
+This will install the `taplo` executable globally:
 
 ```sh
 npm install -g @taplo/cli
 ```
 
-This will install the `taplo` executable globally.
-
-## Installation via yarn
-
 ```sh
 yarn global add @taplo/cli
 ```
 
-This will also install the `taplo` executable globally.
+```sh
+pnpm install -g @taplo/cli
+```
 
-## Run with npx
+## Run without installing
 
-Alternatively you can run it once "without installing" via npx:
+Alternatively you can run it once "without installing":
 
 ```sh
 npx @taplo/cli --help
+```
+
+```sh
+pnpm dlx @taplo/cli --help
 ```


### PR DESCRIPTION
NPM and Yarn already had commands listed, this just shortens the document and adds commands for installing with pnpm.