### PR TITLE
Adapt regex from poetry project

### DIFF
--- a/site/site/public/schemas/pyproject.toml.json
+++ b/site/site/public/schemas/pyproject.toml.json
@@ -9,7 +9,7 @@
     "poetry-author-pattern": {
       "description": "Pattern that matches `Name <email>` like 'King Arthur' or 'Miss Islington &lt;miss-islington@python.org&gt;'.",
       "type": "string",
-      "pattern": "^(?:\\S+?\\s)+?(?:<(?:[a-z\\d!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z\\d!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z\\d](?:[a-z\\d-]*[a-z\\d])?\\.)+[a-z\\d](?:[a-z\\d-]*[a-z\\d])?|\\[(?:(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?)\\.){3}(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?|[a-z\\d-]*[a-z\\d]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])>)?$"
+      "pattern": "^(?:[- .,\\w\\d'’\\\"():&]+)(?: <(?:.+?)>)?"
     },
     "poetry-authors": {
       "type": "array",


### PR DESCRIPTION
This PR solves #360  and  #384 

We adept the Regex in use in the poetry project  https://github.com/python-poetry/poetry-core/blob/main/src/poetry/core/packages/package.py in order to be just as permissive as the Poetry project, for which we are validating.

-----
This PR is our first contribution. We are very open to suggestions and improvements.

This PR was a group effort by Ordina Pythoneers, they would like to thank Ordina for the time to do this.

@SanderBeekhuis 
@RoelAdriaans
@Coen-Smulders

