### PR TITLE
Add option to specify separator for text output

### DIFF
--- a/crates/lsp-async-stub/src/listen.rs
+++ b/crates/lsp-async-stub/src/listen.rs
@@ -89,7 +89,8 @@ impl<W: Clone + 'static> Server<W> {
             } else {
                 Err(anyhow!("got exit message without shutdown notice"))
             }
-        }).await?;
+        })
+        .await?;
 
         Ok(())
     }

--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -212,6 +212,10 @@ pub struct GetCommand {
     ///
     pub pattern: Option<String>,
 
+    /// A string that separates array values when printing to stdout.
+    ///
+    /// If `--separator` is specified with a non text output format,
+    /// the operation will fail.
     #[clap(long)]
     pub separator: Option<String>,
 }

--- a/crates/taplo-cli/src/args.rs
+++ b/crates/taplo-cli/src/args.rs
@@ -211,6 +211,9 @@ pub struct GetCommand {
     /// - dependencies.tokio-*.version
     ///
     pub pattern: Option<String>,
+
+    #[clap(long)]
+    pub separator: Option<String>,
 }
 
 #[derive(Clone, Copy, ArgEnum)]

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -95,7 +95,7 @@ impl<E: Environment> Taplo<E> {
     async fn lint_file(&self, file: &Path) -> Result<(), anyhow::Error> {
         let source = self.env.read_file(file).await?;
         let source = String::from_utf8(source)?;
-        self.lint_source(&*file.to_string_lossy(), &source).await
+        self.lint_source(&file.to_string_lossy(), &source).await
     }
 
     async fn lint_source(&self, file_path: &str, source: &str) -> Result<(), anyhow::Error> {

--- a/crates/taplo-cli/src/commands/queries.rs
+++ b/crates/taplo-cli/src/commands/queries.rs
@@ -103,9 +103,8 @@ impl<E: Environment> Taplo<E> {
                 }
             }
             crate::args::OutputFormat::Value => {
-                let mut buf = String::new();
                 let separator = cmd.separator.as_deref().unwrap_or("\n");
-                if let Some(p) = cmd.pattern {
+                let mut buf = if let Some(p) = cmd.pattern {
                     let p = p.trim_start_matches('.');
 
                     let nodes = p
@@ -118,13 +117,13 @@ impl<E: Environment> Taplo<E> {
                     }
 
                     let values = nodes
-                        .map(|(_, node)| extract_value(&node, &separator))
+                        .map(|(_, node)| extract_value(&node, separator))
                         .collect::<Result<Vec<String>, _>>()?;
 
-                    buf += &values.join(&separator);
+                    values.join(&separator)
                 } else {
-                    buf = extract_value(&node, &separator)?;
-                }
+                    extract_value(&node, separator)?
+                };
 
                 if !cmd.strip_newline {
                     buf += "\n";

--- a/crates/taplo-cli/src/commands/queries.rs
+++ b/crates/taplo-cli/src/commands/queries.rs
@@ -104,7 +104,7 @@ impl<E: Environment> Taplo<E> {
             }
             crate::args::OutputFormat::Value => {
                 let mut buf = String::new();
-                let separator = cmd.separator.unwrap_or("\n".to_string());
+                let separator = cmd.separator.as_deref().unwrap_or("\n");
                 if let Some(p) = cmd.pattern {
                     let p = p.trim_start_matches('.');
 

--- a/crates/taplo-cli/src/commands/queries.rs
+++ b/crates/taplo-cli/src/commands/queries.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow};
+use std::borrow::Cow;
 
 use crate::{
     args::{GetCommand, OutputFormat},
@@ -17,7 +17,7 @@ impl<E: Environment> Taplo<E> {
     pub async fn execute_get(&self, cmd: GetCommand) -> Result<(), anyhow::Error> {
         let mut stdout = self.env.stdout();
 
-        // `--separator` should only be handled for a text output for mat
+        // `--separator` should only be handled for a text output format
         if cmd.separator.is_some() && !matches!(cmd.output_format, OutputFormat::Value) {
             return Err(anyhow!("`--separator` is only value for text output"));
         }

--- a/crates/taplo-cli/src/commands/queries.rs
+++ b/crates/taplo-cli/src/commands/queries.rs
@@ -1,6 +1,9 @@
-use std::borrow::Cow;
+use std::{borrow::Cow};
 
-use crate::{args::GetCommand, Taplo};
+use crate::{
+    args::{GetCommand, OutputFormat},
+    Taplo,
+};
 use anyhow::anyhow;
 use codespan_reporting::files::SimpleFile;
 use taplo::{
@@ -13,6 +16,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 impl<E: Environment> Taplo<E> {
     pub async fn execute_get(&self, cmd: GetCommand) -> Result<(), anyhow::Error> {
         let mut stdout = self.env.stdout();
+
+        // `--separator` should only be handled for a text output for mat
+        if cmd.separator.is_some() && !matches!(cmd.output_format, OutputFormat::Value) {
+            return Err(anyhow!("`--separator` is only value for text output"));
+        }
 
         let source = match &cmd.file_path {
             Some(p) => String::from_utf8(self.env.read_file(p).await?)?,
@@ -93,52 +101,35 @@ impl<E: Environment> Taplo<E> {
                 }
             }
             crate::args::OutputFormat::Value => {
+                let mut buf = String::new();
+                let separator = cmd.separator.unwrap_or("\n".to_string());
                 if let Some(p) = cmd.pattern {
                     let p = p.trim_start_matches('.');
 
-                    let keys = p
+                    let nodes = p
                         .parse::<Keys>()
-                        .map_err(|err| anyhow!("invalid pattern: {err}"))?;
-
-                    let nodes = node
-                        .find_all_matches(keys, false)
+                        .and_then(|keys| node.find_all_matches(keys, false))
                         .map_err(|err| anyhow!("invalid pattern: {err}"))?;
 
                     if nodes.len() == 0 {
                         return Err(anyhow!("no values matched the pattern"));
                     }
 
-                    let mut buf = String::new();
-                    for (_, node) in nodes {
-                        buf += &extract_value(&node)?;
-                        buf += "\n";
-                    }
-                    if cmd.strip_newline {
-                        if buf.ends_with('\n') {
-                            let new_len = buf.trim_end().len();
-                            buf.truncate(new_len);
-                        }
-                    } else if !buf.ends_with('\n') {
-                        buf += "\n";
-                    }
+                    let values = nodes
+                        .map(|(_, node)| extract_value(&node, &separator))
+                        .collect::<Result<Vec<String>, _>>()?;
 
-                    stdout.write_all(buf.as_bytes()).await?;
-                    stdout.flush().await?;
+                    buf += &values.join(&separator);
                 } else {
-                    let mut buf = extract_value(&node)?;
-
-                    if cmd.strip_newline {
-                        if buf.ends_with('\n') {
-                            let new_len = buf.trim_end().len();
-                            buf.truncate(new_len);
-                        }
-                    } else if !buf.ends_with('\n') {
-                        buf += "\n";
-                    }
-
-                    stdout.write_all(buf.as_bytes()).await?;
-                    stdout.flush().await?;
+                    buf = extract_value(&node, &separator)?;
                 }
+
+                if !cmd.strip_newline {
+                    buf += "\n";
+                }
+
+                stdout.write_all(buf.as_bytes()).await?;
+                stdout.flush().await?;
             }
             crate::args::OutputFormat::Toml => {
                 if let Some(p) = cmd.pattern {
@@ -216,7 +207,7 @@ impl<E: Environment> Taplo<E> {
     }
 }
 
-fn extract_value(node: &Node) -> Result<String, anyhow::Error> {
+fn extract_value(node: &Node, separator: &str) -> Result<String, anyhow::Error> {
     Ok(match node {
         Node::Table(_) => {
             return Err(anyhow!(
@@ -224,19 +215,13 @@ fn extract_value(node: &Node) -> Result<String, anyhow::Error> {
             ))
         }
         Node::Array(arr) => {
-            let mut s = String::new();
+            let mut values = Vec::new();
 
-            let mut start = true;
-            for item in &**arr.items().read() {
-                if !start {
-                    s += "\n";
-                }
-                start = false;
-
-                s += &extract_value(item)?;
+            for node in arr.items().read().iter() {
+                values.push(extract_value(node, separator)?);
             }
 
-            s
+            values.join(separator)
         }
         Node::Bool(b) => b.value().to_string(),
         Node::Str(s) => s.value().to_string(),

--- a/crates/taplo-cli/src/commands/queries.rs
+++ b/crates/taplo-cli/src/commands/queries.rs
@@ -120,7 +120,7 @@ impl<E: Environment> Taplo<E> {
                         .map(|(_, node)| extract_value(&node, separator))
                         .collect::<Result<Vec<String>, _>>()?;
 
-                    values.join(&separator)
+                    values.join(separator)
                 } else {
                     extract_value(&node, separator)?
                 };

--- a/crates/taplo-cli/src/commands/queries.rs
+++ b/crates/taplo-cli/src/commands/queries.rs
@@ -19,7 +19,9 @@ impl<E: Environment> Taplo<E> {
 
         // `--separator` should only be handled for a text output format
         if cmd.separator.is_some() && !matches!(cmd.output_format, OutputFormat::Value) {
-            return Err(anyhow!("`--separator` is only value for text output"));
+            return Err(anyhow!(
+                "`--separator` is only valid for `--output-format value`"
+            ));
         }
 
         let source = match &cmd.file_path {

--- a/crates/taplo-common/src/schema/cache.rs
+++ b/crates/taplo-common/src/schema/cache.rs
@@ -31,7 +31,10 @@ impl<E: Environment> Cache<E> {
             )))),
             lru_expires_by: Arc::new(Mutex::new(env.now() + DEFAULT_LRU_CACHE_EXPIRATION_TIME)),
             env,
-            schemas: Arc::new(Mutex::new(LruCache::with_hasher(10, ahash::RandomState::new()))),
+            schemas: Arc::new(Mutex::new(LruCache::with_hasher(
+                10,
+                ahash::RandomState::new(),
+            ))),
             cache_path: Default::default(),
         }
     }

--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -1085,8 +1085,7 @@ fn format_array(node: SyntaxNode, options: &Options, context: &Context) -> impl 
                         skip_newlines = 0;
                     }
 
-                    formatted
-                        .extend(options.newlines(newline_count.saturating_sub(skip_newlines)));
+                    formatted.extend(options.newlines(newline_count.saturating_sub(skip_newlines)));
                 }
                 COMMENT => {
                     let newline_before = t

--- a/crates/taplo/src/parser/mod.rs
+++ b/crates/taplo/src/parser/mod.rs
@@ -918,7 +918,7 @@ fn check_underscores(s: &str, radix: u32) -> bool {
 
 /// The final results of a parsing.
 /// It contains the green tree, and
-/// the errors that ocurred during parsing.
+/// the errors that occurred during parsing.
 #[derive(Debug, Clone)]
 pub struct Parse {
     pub green_node: GreenNode,

--- a/crates/taplo/src/tests/formatter.rs
+++ b/crates/taplo/src/tests/formatter.rs
@@ -1125,9 +1125,7 @@ my_array = [
 ]
 "#;
 
-    let formatted = crate::formatter::format(
-        src, Default::default()
-    );
+    let formatted = crate::formatter::format(src, Default::default());
 
     assert_format!(expected, &formatted);
 }


### PR DESCRIPTION
Added `--separator <str>` flag for `taplo get`.


From the helpdoc:
```
 --separator <SEPARATOR>
        A string that separates array values when printing to stdout.

        If `--separator` is specified with a non text output format, the operation will fail.
```