### PR TITLE
chore: make link in settings description clickable

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -387,7 +387,7 @@
           "scope": "resource",
           "type": "array",
           "default": [],
-          "description": "Array of Taplo rules in JSON format, see [Configuration File - Rules](https://taplo.tamasfe.dev/configuration/file.html#rules). The rules given here are appended to existing rules from config files, if any. There is no conversion done, all object keys must be snake_case, including formatting rules."
+          "markdownDescription": "Array of Taplo rules in JSON format, see [Configuration File - Rules](https://taplo.tamasfe.dev/configuration/file.html#rules). The rules given here are appended to existing rules from config files, if any. There is no conversion done, all object keys must be snake_case, including formatting rules."
         }
       }
     }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -387,7 +387,7 @@
           "scope": "resource",
           "type": "array",
           "default": [],
-          "description": "Array of Taplo rules in JSON format, see https://taplo.tamasfe.dev/configuration/file.html#rules. The rules given here are appended to existing rules from config files, if any. There is no conversion done, all object keys must be snake_case, including formatting rules."
+          "description": "Array of Taplo rules in JSON format, see [Configuration File - Rules](https://taplo.tamasfe.dev/configuration/file.html#rules). The rules given here are appended to existing rules from config files, if any. There is no conversion done, all object keys must be snake_case, including formatting rules."
         }
       }
     }


### PR DESCRIPTION
For some reason you have to make links in settings descriptions with markdown syntax for them to turn into clickable links.

![Screenshot 2023-10-18 at 21 05 28 (Visual Studio Code)](https://github.com/tamasfe/taplo/assets/47499684/5f57bedd-cc29-4825-8cdc-4212936e9e8b)

*The link in the bottom right, which uses the bracket parenthesis syntax (`[123](https://example.com)`), is underlined and clickable while the plain link at the top center is not converted into a link and has to copy pasted.*

I just took the title of the docs page and the section heading as the link text.