### PR TITLE
Use JSON Schema draft 2020-12

### DIFF
--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4.3"
 indexmap = { version = "1.6.0", features = ["serde", "rayon"] }
 itertools = "0.10.3"
 json_value_merge = "2.0.0"
-jsonschema = { version = "0.17.1", default-features = false }
+jsonschema = { version = "0.17.1", default-features = false, features = ["draft202012"] }
 lru = "0.7.2"
 parking_lot = "0.12.0"
 percent-encoding = "2.1.0"

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -260,6 +260,7 @@ impl<E: Environment> Schemas<E> {
             .with_resolver(CacheSchemaResolver {
                 cache: self.cache().clone(),
             })
+            .with_draft(jsonschema::Draft::Draft202012)
             .with_format("semver", formats::semver)
             .with_format("semver-requirement", formats::semver_req)
             .compile(schema)


### PR DESCRIPTION
I'm not sure we want to merge this. Not sure of the implications and why `jsonschema` doesn't figure out the draft version based on the `$schema` value in the schema.

Fixes #497