### PR TITLE
Clarify that array_auto_expand is conditional

### DIFF
--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -60,8 +60,8 @@ create_options!(
         /// arrays.
         pub array_trailing_comma: bool,
 
-        /// Automatically expand arrays to multiple lines
-        /// if they're too long.
+        /// Automatically expand arrays to multiple lines once they
+        /// exceed the configured `column_width`.
         pub array_auto_expand: bool,
 
         /// Expand values (e.g.) inside inline tables

--- a/site/site/configuration/formatter-options.md
+++ b/site/site/configuration/formatter-options.md
@@ -15,7 +15,7 @@ In some environments (e.g., Visual Studio Code), one needs to reload the extensi
 |     align_entries     |       Align entries vertically. Entries that have table headers, comments, or blank lines between them are not aligned.        |     false      |
 |    align_comments     | Align consecutive comments after entries and items vertically. This applies to comments that are after entries or array items. |      true      |
 | array_trailing_comma  |                                           Put trailing commas for multiline arrays.                                            |      true      |
-|   array_auto_expand   |                                         Automatically expand arrays to multiple lines                                          |      true      |
+|   array_auto_expand   |                   Automatically expand arrays to multiple lines when they exceed `column_width` characters.                    |      true      |
 |  array_auto_collapse  |                                     Automatically collapse arrays if they fit in one line.                                     |      true      |
 |    compact_arrays     |                                       Omit whitespace padding inside single-line arrays.                                       |      true      |
 | compact_inline_tables |                                         Omit whitespace padding inside inline tables.                                          |     false      |


### PR DESCRIPTION
Addresses part of #390.

The `array_auto_expand` formatter configuration option will prefer to leave arrays on a single line until they exceed the configured column length. The documentation didn't make this caveat clear, and lead some users to expect that all arrays would be expanded regardless.

This does not modify behavior at all, just documents it.