### PR TITLE
Do not enable default-tls unconditionally

### DIFF
--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -35,7 +35,7 @@ schemars = "0.8"
 serde = "1"
 serde_json = "1"
 taplo = { version = "0.13.0", path = "../taplo", features = ["serde"] }
-taplo-common = { version = "0.5.0", path = "../taplo-common" }
+taplo-common = { version = "0.5.0", path = "../taplo-common", default-features = false }
 taplo-lsp = { version = "0.7.0", path = "../taplo-lsp", default-features = false, optional = true }
 time = { version = "0.3", features = ["parsing"] }
 toml = "0.7"

--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -27,7 +27,6 @@ parking_lot = "0.12.0"
 percent-encoding = "2.1.0"
 regex = "1.5.4"
 reqwest = { version = "0.11.9", default-features = false, features = [
-  "default-tls",
   "json",
 ] }
 schemars = { version = "0.8.8", features = ["url"] }
@@ -60,6 +59,10 @@ tokio = { version = "1.24.2", features = [
 ], default-features = false }
 
 [features]
+# We only set a default such that `cargo publish` doesn't complain. Crates
+# depending on taplo-common should disable default features and explicitly set
+# the features they need.
+default = ["rustls-tls"]
 # default-tls enables native-tls but without enabling native-tls specific features.
 native-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]

--- a/crates/taplo-lsp/Cargo.toml
+++ b/crates/taplo-lsp/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 tap = "1.0.1"
 taplo = { version = "0.13.0", path = "../taplo", features = ["serde"] }
-taplo-common = { version = "0.5.0", path = "../taplo-common" }
+taplo-common = { version = "0.5.0", path = "../taplo-common", default-features = false }
 time = { version = "0.3", features = ["formatting", "parsing"] }
 toml = "0.7"
 tracing = "0.1.29"

--- a/crates/taplo-wasm/Cargo.toml
+++ b/crates/taplo-wasm/Cargo.toml
@@ -23,7 +23,9 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 taplo = { path = "../taplo" }
 taplo-cli = { path = "../taplo-cli", optional = true }
-taplo-common = { path = "../taplo-common", features = ["rustls-tls"] }
+taplo-common = { path = "../taplo-common", default-features = false, features = [
+  "rustls-tls",
+] }
 taplo-lsp = { path = "../taplo-lsp", optional = true }
 time = { version = "0.3.9", features = ["parsing"] }
 tokio = { version = "1.19.2", default-features = false }


### PR DESCRIPTION
This reverts 4be1d1eb9fba62ddd6cc7cf53058b6bce3d66c7c and make it more convenient to build taplo-common without explicitly providing a feature.

Fixes #553 