### PR TITLE
Add repository attribute to crates missing it

### DIFF
--- a/crates/lsp-async-stub/Cargo.toml
+++ b/crates/lsp-async-stub/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 name = "lsp-async-stub"
 version = "0.6.3"
 license = "MIT"
+repository = "https://github.com/tamasfe/taplo"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.1"
 edition = "2021"
 description = "Shared code for taplo utilities."
 license = "MIT"
+repository = "https://github.com/tamasfe/taplo"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/taplo-wasm/Cargo.toml
+++ b/crates/taplo-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "taplo-wasm"
 version = "0.2.1"
 edition = "2021"
 publish = false
+repository = "https://github.com/tamasfe/taplo"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Hi! While scraping crates.io I've found some of your crates are missing the `repository` field, making it harder for users or automated tools to find the source git repository. Git PR fixes it by adding the repository field to those crates.