### PR TITLE
Fix realign of comment makes debug assert fail

### DIFF
--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -681,7 +681,7 @@ fn add_entries(
                     entry.value.clear();
 
                     if let Some(c) = value.trailing_comment() {
-                        debug_assert!(entry.comment.is_none());
+                        debug_assert!(entry.comment.is_none() || entry.comment.clone().unwrap() == c);
                         entry.comment = Some(c);
                     }
 

--- a/crates/taplo/src/tests/formatter.rs
+++ b/crates/taplo/src/tests/formatter.rs
@@ -1,6 +1,7 @@
 use difference::Changeset;
 
 use crate::formatter;
+use crate::formatter::Options;
 
 macro_rules! assert_format {
     ($expected:expr, $actual:expr) => {
@@ -1161,6 +1162,24 @@ my_array = [
 "#;
 
     let formatted = crate::formatter::format(src, Default::default());
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn test_comment_after_entry() {
+    let src = r#"
+a = "b" # comment
+"#;
+
+    let expected = r#"
+a = "b" # comment
+"#;
+    let opt = Options {
+        column_width: 1,
+        ..Default::default()
+    };
+    let formatted = crate::formatter::format(src, opt);
 
     assert_format!(expected, &formatted);
 }


### PR DESCRIPTION
In this case, the two comments match up.

Discovered while doing https://github.com/gaborbernat/pyproject-fmt-rust