### PR TITLE
Move to `ignore` for ignoring files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.5",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2260,7 @@ dependencies = [
  "futures",
  "glob",
  "hex",
+ "ignore",
  "itertools",
  "lsp-async-stub",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ getrandom          = { version = "0.2", default-features = false }
 glob               = { version = "0.3" }
 globset            = { version = "0.4.8" }
 hex                = { version = "0.4" }
+ignore             = { version = "0.4" }
 indexmap           = { version = "2.2" }
 itertools          = { version = "0.10.3" }
 lsp-types          = { version = "0.93.0" }

--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -30,6 +30,7 @@ codespan-reporting = { version = "0.11.1" }
 futures            = { workspace = true }
 glob               = { workspace = true }
 hex                = { workspace = true }
+ignore             = { workspace = true }
 itertools          = { workspace = true }
 once_cell          = { workspace = true }
 regex              = { workspace = true }

--- a/crates/taplo-cli/src/commands/format.rs
+++ b/crates/taplo-cli/src/commands/format.rs
@@ -214,7 +214,7 @@ impl<E: Environment> Taplo<E> {
             .ok_or_else(|| anyhow!("could not figure the current working directory"))?;
 
         let files = self
-            .collect_files(&cwd, &config, mem::take(&mut cmd.files).into_iter())
+            .files_iter(&cwd, &config, mem::take(&mut cmd.files).into_iter())
             .await?;
 
         let mut result = Ok(());

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -77,7 +77,7 @@ impl<E: Environment> Taplo<E> {
             .ok_or_else(|| anyhow!("could not figure the current working directory"))?;
 
         let files = self
-            .collect_files(&cwd, &config, cmd.files.into_iter())
+            .files_iter(&cwd, &config, cmd.files.into_iter())
             .await?;
 
         let mut result = Ok(());

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -53,7 +53,7 @@ impl<E: Environment> Taplo<E> {
             }
         }
 
-        if matches!(cmd.files.get(0).map(|it| it.as_str()), Some("-")) {
+        if matches!(cmd.files.first().map(|it| it.as_str()), Some("-")) {
             self.lint_stdin(cmd).await
         } else {
             self.lint_files(cmd).await

--- a/crates/taplo-cli/src/commands/toml_test.rs
+++ b/crates/taplo-cli/src/commands/toml_test.rs
@@ -90,7 +90,7 @@ impl<'a> TomlTestValue<'a> {
     }
 }
 
-impl<'a> Serialize for TomlTestValue<'a> {
+impl Serialize for TomlTestValue<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context};
 use args::GeneralArgs;
-use itertools::Itertools;
 use std::{
     path::{Path, PathBuf},
     str,
@@ -13,6 +12,8 @@ use taplo_common::{config::Config, environment::Environment, util::Normalize};
 pub mod args;
 pub mod commands;
 pub mod printing;
+
+pub type EntryIter<'a, F> = std::iter::FilterMap<ignore::Walk, F>;
 
 pub struct Taplo<E: Environment> {
     env: E,
@@ -88,17 +89,25 @@ impl<E: Environment> Taplo<E> {
     }
 
     #[tracing::instrument(skip_all, fields(?cwd))]
-    async fn collect_files(
+    async fn files_iter(
         &self,
         cwd: &Path,
         config: &Config,
         arg_patterns: impl Iterator<Item = String>,
-    ) -> Result<Vec<PathBuf>, anyhow::Error> {
+    ) -> Result<
+        EntryIter<'_, Box<dyn FnMut(Result<ignore::DirEntry, ignore::Error>) -> Option<PathBuf>>>,
+        anyhow::Error,
+    > {
+        tracing::trace!("Nomarlizing patterns to absolute ones...");
+
         let mut patterns: Vec<String> = arg_patterns
             .map(|pat| {
                 if !self.env.is_absolute(Path::new(&pat)) {
-                    cwd.join(&pat).normalize().to_string_lossy().into_owned()
+                    let pat = cwd.join(&pat).normalize().to_string_lossy().into_owned();
+                    tracing::debug!("Arg(abs) {} ", &pat);
+                    pat
                 } else {
+                    tracing::debug!("Arg(rel) {} ", &pat);
                     pat
                 }
             })
@@ -115,33 +124,65 @@ impl<E: Environment> Taplo<E> {
             };
         };
 
-        let patterns = patterns
-            .into_iter()
-            .unique()
-            .map(|p| glob::Pattern::new(&p).map(|_| p))
-            .collect::<Result<Vec<_>, _>>()?;
+        tracing::trace!("Compiled patterns");
 
-        let files = patterns
-            .into_iter()
-            .map(|pat| self.env.glob_files_normalized(&pat))
-            .collect::<Result<Vec<_>, _>>()
-            .into_iter()
+        let mut skip_patterns = vec![];
+        let mut keep_patterns = vec![];
+
+        let opts = glob::MatchOptions {
+            case_sensitive: true,
+            ..Default::default()
+        };
+
+        let cwd = cwd.to_path_buf();
+
+        let mut bldr = ignore::WalkBuilder::new(&cwd);
+        bldr.git_ignore(true)
+            .git_exclude(true)
+            .git_global(true)
+            .ignore(true)
+            .hidden(false)
+            .same_file_system(true);
+
+        for skip_pattern in config.exclude.iter().cloned().flatten() {
+            if let Ok(pat) = glob::Pattern::new(&skip_pattern) {
+                tracing::trace!("Compiling pattern: {skip_pattern}");
+                skip_patterns.push(pat.clone());
+                bldr.filter_entry(move |entry| !pat.matches_path_with(entry.path(), opts));
+            }
+        }
+        for keep_pattern in config
+            .include
+            .iter()
+            .cloned()
             .flatten()
-            .flatten()
-            .collect::<Vec<_>>();
+            .map(|x| x.to_owned())
+            .chain(patterns.into_iter())
+        {
+            if let Ok(pat) = glob::Pattern::new(&keep_pattern) {
+                tracing::trace!("Compiling pattern: {pat}");
+                keep_patterns.push(pat.clone());
+                bldr.filter_entry(move |entry| pat.matches_path_with(entry.path(), opts));
+            }
+        }
+        let walker = bldr.build();
 
-        let total = files.len();
-
-        let files = files
-            .into_iter()
-            .filter(|path| config.is_included(path))
-            .collect::<Vec<_>>();
-
-        let excluded = total - files.len();
-
-        tracing::info!(total, excluded, "found files");
-
-        Ok(files)
+        Ok(walker.filter_map(Box::new(
+            move |entry: Result<ignore::DirEntry, ignore::Error>| -> Option<PathBuf> {
+                let entry = entry.ok()?;
+                debug_assert!(!skip_patterns
+                    .iter()
+                    .any(|pat| pat.matches_path_with(entry.path(), opts.clone())));
+                debug_assert!(keep_patterns
+                    .iter()
+                    .any(|pat| pat.matches_path_with(entry.path(), opts)));
+                if entry.path() == cwd {
+                    None
+                } else {
+                    Some(entry.path().to_path_buf())
+                }
+            },
+        )))
     }
 }
 

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -137,9 +137,11 @@ impl<E: Environment> Taplo<E> {
         let cwd = cwd.to_path_buf();
 
         let mut bldr = ignore::WalkBuilder::new(&cwd);
-        bldr.git_ignore(true)
+        bldr.standard_filters(false)
+            .git_ignore(true)
             .git_exclude(true)
             .git_global(true)
+            .parents(true)
             .ignore(true)
             .hidden(false)
             .same_file_system(true);
@@ -154,7 +156,8 @@ impl<E: Environment> Taplo<E> {
         for keep_pattern in config
             .include
             .iter()
-            .flatten().cloned()
+            .flatten()
+            .cloned()
             .map(|x| x.to_owned())
             .chain(patterns.into_iter())
         {

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -179,7 +179,9 @@ impl<E: Environment> Taplo<E> {
                 if entry.path() == cwd {
                     None
                 } else {
-                    Some(entry.path().to_path_buf())
+                    let p = entry.path().to_path_buf();
+                    tracing::debug!("Path passed filters: {}", p.display());
+                    Some(p)
                 }
             },
         )))

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -144,8 +144,8 @@ impl<E: Environment> Taplo<E> {
             .hidden(false)
             .same_file_system(true);
 
-        for skip_pattern in config.exclude.iter().cloned().flatten() {
-            if let Ok(pat) = glob::Pattern::new(&skip_pattern) {
+        for skip_pattern in config.exclude.iter().flatten() {
+            if let Ok(pat) = glob::Pattern::new(skip_pattern) {
                 tracing::trace!("Compiling pattern: {skip_pattern}");
                 skip_patterns.push(pat.clone());
                 bldr.filter_entry(move |entry| !pat.matches_path_with(entry.path(), opts));
@@ -154,8 +154,7 @@ impl<E: Environment> Taplo<E> {
         for keep_pattern in config
             .include
             .iter()
-            .cloned()
-            .flatten()
+            .flatten().cloned()
             .map(|x| x.to_owned())
             .chain(patterns.into_iter())
         {
@@ -172,7 +171,7 @@ impl<E: Environment> Taplo<E> {
                 let entry = entry.ok()?;
                 debug_assert!(!skip_patterns
                     .iter()
-                    .any(|pat| pat.matches_path_with(entry.path(), opts.clone())));
+                    .any(|pat| pat.matches_path_with(entry.path(), opts)));
                 debug_assert!(keep_patterns
                     .iter()
                     .any(|pat| pat.matches_path_with(entry.path(), opts)));

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -716,21 +716,20 @@ impl NodeValidationError {
         Ok(Self { keys, node, error })
     }
 
-    pub fn text_ranges(&self) -> Box<dyn Iterator<Item = TextRange> + '_> {
+    #[must_use] pub fn text_ranges(&self) -> Box<dyn Iterator<Item = TextRange> + '_> {
         match self.error.kind {
             ValidationErrorKind::AdditionalProperties { .. } => {
                 let include_children = false;
 
                 if self.keys.is_empty() {
-                    return Box::new(self.node.text_ranges(include_children).into_iter());
+                    return Box::new(self.node.text_ranges(include_children));
                 }
 
                 Box::new(
                     self.keys
                         .clone()
                         .into_iter()
-                        .map(move |key| self.node.get(key).text_ranges(include_children))
-                        .flatten(),
+                        .flat_map(move |key| self.node.get(key).text_ranges(include_children)),
                 )
             }
             _ => Box::new(self.node.text_ranges(true)),

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -716,7 +716,8 @@ impl NodeValidationError {
         Ok(Self { keys, node, error })
     }
 
-    #[must_use] pub fn text_ranges(&self) -> Box<dyn Iterator<Item = TextRange> + '_> {
+    #[must_use]
+    pub fn text_ranges(&self) -> Box<dyn Iterator<Item = TextRange> + '_> {
         match self.error.kind {
             ValidationErrorKind::AdditionalProperties { .. } => {
                 let include_children = false;

--- a/crates/taplo-common/src/util.rs
+++ b/crates/taplo-common/src/util.rs
@@ -62,13 +62,13 @@ impl PartialEq for ArcHashValue {
 #[derive(Eq)]
 pub struct HashValue<'v>(pub &'v Value);
 
-impl<'v> PartialEq for HashValue<'v> {
+impl PartialEq for HashValue<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<'v> Hash for HashValue<'v> {
+impl Hash for HashValue<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match &self.0 {
             Value::Null => 0.hash(state),
@@ -129,7 +129,7 @@ pub fn get_reqwest_client(timeout: std::time::Duration) -> Result<reqwest::Clien
         path: std::ffi::OsString,
     ) -> reqwest::ClientBuilder {
         fn get_cert(path: &Path) -> Result<reqwest::Certificate, anyhow::Error> {
-            let is_der = path.extension().map_or(false, |ext| ext == "der");
+            let is_der = path.extension().is_some_and(|ext| ext == "der");
             let buf = std::fs::read(path)?;
             tracing::info!(
                 "Found a custom CA {}. Reading the CA...",

--- a/crates/taplo-lsp/src/handlers/completion.rs
+++ b/crates/taplo-lsp/src/handlers/completion.rs
@@ -83,7 +83,8 @@ pub async fn completion<E: Environment>(
                     s["type"].is_null()
                         || s["type"] == "object"
                         || s["type"]
-                            .as_array().is_some_and(|arr| arr.iter().any(|v| v == "object"))
+                            .as_array()
+                            .is_some_and(|arr| arr.iter().any(|v| v == "object"))
                 })
             }) {
             Ok(s) => s,
@@ -207,8 +208,7 @@ pub async fn completion<E: Environment>(
                 .into_iter()
                 // Filter out existing items.
                 .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
-                    Some(n) => n
-                        .as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
+                    Some(n) => n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                     None => true,
                 })
                 .map(|(_, relative_keys, schema)| CompletionItem {
@@ -315,8 +315,7 @@ pub async fn completion<E: Environment>(
                     .into_iter()
                     // Filter out existing items.
                     .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
-                        Some(n) => n
-                            .as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
+                        Some(n) => n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                         None => true,
                     })
                     .map(|(_, relative_keys, schema)| CompletionItem {
@@ -414,8 +413,7 @@ pub async fn completion<E: Environment>(
             .into_iter()
             // Filter out existing items.
             .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
-                Some(n) => n
-                    .as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
+                Some(n) => n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                 None => true,
             })
             .map(|(_, relative_keys, schema)| CompletionItem {

--- a/crates/taplo-lsp/src/handlers/completion.rs
+++ b/crates/taplo-lsp/src/handlers/completion.rs
@@ -83,8 +83,7 @@ pub async fn completion<E: Environment>(
                     s["type"].is_null()
                         || s["type"] == "object"
                         || s["type"]
-                            .as_array()
-                            .map_or(false, |arr| arr.iter().any(|v| v == "object"))
+                            .as_array().is_some_and(|arr| arr.iter().any(|v| v == "object"))
                 })
             }) {
             Ok(s) => s,
@@ -113,8 +112,7 @@ pub async fn completion<E: Environment>(
                 .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
                     Some(n) => {
                         node.0 == *full_key
-                            || n.as_table()
-                                .map_or(false, |t| t.kind() == TableKind::Pseudo)
+                            || n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo)
                     }
                     None => true,
                 })
@@ -210,8 +208,7 @@ pub async fn completion<E: Environment>(
                 // Filter out existing items.
                 .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
                     Some(n) => n
-                        .as_table()
-                        .map_or(false, |t| t.kind() == TableKind::Pseudo),
+                        .as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                     None => true,
                 })
                 .map(|(_, relative_keys, schema)| CompletionItem {
@@ -319,8 +316,7 @@ pub async fn completion<E: Environment>(
                     // Filter out existing items.
                     .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
                         Some(n) => n
-                            .as_table()
-                            .map_or(false, |t| t.kind() == TableKind::Pseudo),
+                            .as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                         None => true,
                     })
                     .map(|(_, relative_keys, schema)| CompletionItem {
@@ -419,8 +415,7 @@ pub async fn completion<E: Environment>(
             // Filter out existing items.
             .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
                 Some(n) => n
-                    .as_table()
-                    .map_or(false, |t| t.kind() == TableKind::Pseudo),
+                    .as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                 None => true,
             })
             .map(|(_, relative_keys, schema)| CompletionItem {

--- a/crates/taplo-lsp/src/handlers/hover.rs
+++ b/crates/taplo-lsp/src/handlers/hover.rs
@@ -142,11 +142,7 @@ pub(crate) async fn hover<E: Environment>(
                         s += desc;
                     }
 
-                    let link_title = if let Some(s) = schema["title"].as_str() {
-                        s
-                    } else {
-                        "..."
-                    };
+                    let link_title = schema["title"].as_str().unwrap_or("...");
 
                     if links_in_hover {
                         if let Some(link) = &ext_links.key {
@@ -212,11 +208,7 @@ pub(crate) async fn hover<E: Environment>(
                                     if let Some(enum_docs) = enum_docs.get(idx).cloned().flatten() {
                                         if links_in_hover {
                                             let link_title =
-                                                if let Some(s) = schema["title"].as_str() {
-                                                    s
-                                                } else {
-                                                    "..."
-                                                };
+                                                schema["title"].as_str().unwrap_or("...");
 
                                             if let Some(enum_link) =
                                                 enum_links.get(idx).and_then(Option::as_ref)

--- a/crates/taplo-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/taplo-lsp/src/handlers/semantic_tokens.rs
@@ -85,7 +85,8 @@ pub fn create_tokens(syntax: &SyntaxNode, mapper: &Mapper) -> Vec<SemanticToken>
                     let is_table_key = token
                         .parent()
                         .and_then(|p| p.next_sibling())
-                        .and_then(|t| t.first_child()).is_some_and(|t| t.kind() == INLINE_TABLE);
+                        .and_then(|t| t.first_child())
+                        .is_some_and(|t| t.kind() == INLINE_TABLE);
 
                     if is_table_key {
                         builder.add_token(&token, TokenType::TomlTableKey, &[]);
@@ -96,7 +97,8 @@ pub fn create_tokens(syntax: &SyntaxNode, mapper: &Mapper) -> Vec<SemanticToken>
                     let is_array_key = token
                         .parent()
                         .and_then(|p| p.next_sibling())
-                        .and_then(|t| t.first_child()).is_some_and(|t| t.kind() == ARRAY);
+                        .and_then(|t| t.first_child())
+                        .is_some_and(|t| t.kind() == ARRAY);
 
                     if is_array_key {
                         builder.add_token(&token, TokenType::TomlArrayKey, &[]);

--- a/crates/taplo-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/taplo-lsp/src/handlers/semantic_tokens.rs
@@ -85,8 +85,7 @@ pub fn create_tokens(syntax: &SyntaxNode, mapper: &Mapper) -> Vec<SemanticToken>
                     let is_table_key = token
                         .parent()
                         .and_then(|p| p.next_sibling())
-                        .and_then(|t| t.first_child())
-                        .map_or(false, |t| t.kind() == INLINE_TABLE);
+                        .and_then(|t| t.first_child()).is_some_and(|t| t.kind() == INLINE_TABLE);
 
                     if is_table_key {
                         builder.add_token(&token, TokenType::TomlTableKey, &[]);
@@ -97,8 +96,7 @@ pub fn create_tokens(syntax: &SyntaxNode, mapper: &Mapper) -> Vec<SemanticToken>
                     let is_array_key = token
                         .parent()
                         .and_then(|p| p.next_sibling())
-                        .and_then(|t| t.first_child())
-                        .map_or(false, |t| t.kind() == ARRAY);
+                        .and_then(|t| t.first_child()).is_some_and(|t| t.kind() == ARRAY);
 
                     if is_array_key {
                         builder.add_token(&token, TokenType::TomlArrayKey, &[]);

--- a/crates/taplo-lsp/src/query.rs
+++ b/crates/taplo-lsp/src/query.rs
@@ -293,7 +293,8 @@ impl Query {
 
     #[must_use]
     pub fn in_entry_keys(&self) -> bool {
-        self.entry_key().is_some_and(|k| k.text_range().contains(self.offset))
+        self.entry_key()
+            .is_some_and(|k| k.text_range().contains(self.offset))
     }
 
     #[must_use]
@@ -315,7 +316,8 @@ impl Query {
     #[must_use]
     pub fn in_entry_value(&self) -> bool {
         let in_value = self
-            .entry_value().is_some_and(|k| k.text_range().contains_inclusive(self.offset));
+            .entry_value()
+            .is_some_and(|k| k.text_range().contains_inclusive(self.offset));
 
         if in_value {
             return true;

--- a/crates/taplo-lsp/src/query.rs
+++ b/crates/taplo-lsp/src/query.rs
@@ -293,8 +293,7 @@ impl Query {
 
     #[must_use]
     pub fn in_entry_keys(&self) -> bool {
-        self.entry_key()
-            .map_or(false, |k| k.text_range().contains(self.offset))
+        self.entry_key().is_some_and(|k| k.text_range().contains(self.offset))
     }
 
     #[must_use]
@@ -316,9 +315,7 @@ impl Query {
     #[must_use]
     pub fn in_entry_value(&self) -> bool {
         let in_value = self
-            .entry_value()
-            // We are inside the value even if the cursor is right after it.
-            .map_or(false, |k| k.text_range().contains_inclusive(self.offset));
+            .entry_value().is_some_and(|k| k.text_range().contains_inclusive(self.offset));
 
         if in_value {
             return true;
@@ -341,7 +338,7 @@ impl Query {
 
     #[must_use]
     pub fn is_single_quote_value(&self) -> bool {
-        self.entry_value().map_or(false, |v| {
+        self.entry_value().is_some_and(|v| {
             v.descendants_with_tokens()
                 .any(|t| matches!(t.kind(), STRING_LITERAL | MULTI_LINE_STRING_LITERAL))
         })

--- a/crates/taplo-lsp/src/world.rs
+++ b/crates/taplo-lsp/src/world.rs
@@ -246,7 +246,7 @@ impl<E: Environment> WorkspaceState<E> {
             };
 
             if let Some(config_path) = config_path {
-                tracing::info!(path = ?config_path, "using config file");
+                tracing::debug!(path = ?config_path, "using config file");
                 self.taplo_config =
                     toml::from_str(str::from_utf8(&env.read_file(&config_path).await?)?)?;
             }

--- a/crates/taplo-wasm/src/lib.rs
+++ b/crates/taplo-wasm/src/lib.rs
@@ -213,7 +213,6 @@ pub async fn run_cli(env: JsValue, args: JsValue) -> Result<(), JsError> {
 #[cfg(feature = "lsp")]
 #[wasm_bindgen]
 pub fn create_lsp(env: JsValue, lsp_interface: JsValue) -> lsp::TaploWasmLsp {
-
     use taplo_common::log::setup_stderr_logging;
 
     let env = WasmEnvironment::from(env);

--- a/crates/taplo-wasm/src/lib.rs
+++ b/crates/taplo-wasm/src/lib.rs
@@ -213,7 +213,7 @@ pub async fn run_cli(env: JsValue, args: JsValue) -> Result<(), JsError> {
 #[cfg(feature = "lsp")]
 #[wasm_bindgen]
 pub fn create_lsp(env: JsValue, lsp_interface: JsValue) -> lsp::TaploWasmLsp {
-    use taplo_common::environment::Environment;
+
     use taplo_common::log::setup_stderr_logging;
 
     let env = WasmEnvironment::from(env);

--- a/crates/taplo/src/dom/index.rs
+++ b/crates/taplo/src/dom/index.rs
@@ -50,8 +50,8 @@ impl Index for String {
     }
 }
 
-impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
-impl<'a, T> Index for &'a T
+impl<T> Sealed for &T where T: ?Sized + Sealed {}
+impl<T> Index for &T
 where
     T: ?Sized + Index,
 {

--- a/crates/taplo/src/dom/node.rs
+++ b/crates/taplo/src/dom/node.rs
@@ -180,7 +180,7 @@ impl Node {
         &self,
         keys: Keys,
         include_children: bool,
-    ) -> Result<impl Iterator<Item = (Keys, Node)> + ExactSizeIterator, Error> {
+    ) -> Result<impl ExactSizeIterator<Item = (Keys, Node)>, Error> {
         let mut all = self.flat_iter_impl();
 
         let mut err: Option<Error> = None;

--- a/crates/taplo/src/parser/mod.rs
+++ b/crates/taplo/src/parser/mod.rs
@@ -74,7 +74,7 @@ pub(crate) struct Parser<'p> {
     errors: Vec<Error>,
 }
 
-impl<'p> Parser<'p> {
+impl Parser<'_> {
     /// Required for patch syntax
     /// and key matches.
     ///

--- a/crates/taplo/src/syntax.rs
+++ b/crates/taplo/src/syntax.rs
@@ -141,7 +141,7 @@ fn lex_string(lex: &mut Lexer<SyntaxKind>) -> bool {
         }
 
         if c == '"' && !escaped {
-            lex.bump(remainder[0..total_len].as_bytes().len());
+            lex.bump(remainder[0..total_len].len());
             return true;
         }
 
@@ -171,7 +171,7 @@ fn lex_multi_line_string(lex: &mut Lexer<SyntaxKind>) -> bool {
                     return false;
                 }
 
-                lex.bump(remainder[0..total_len].as_bytes().len());
+                lex.bump(remainder[0..total_len].len());
                 return true;
             } else {
                 quote_count += 1;
@@ -205,7 +205,7 @@ fn lex_multi_line_string(lex: &mut Lexer<SyntaxKind>) -> bool {
             return false;
         }
 
-        lex.bump(remainder[0..total_len].as_bytes().len());
+        lex.bump(remainder[0..total_len].len());
         true
     } else {
         false
@@ -220,7 +220,7 @@ fn lex_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
         total_len += c.len_utf8();
 
         if c == '\'' {
-            lex.bump(remainder[0..total_len].as_bytes().len());
+            lex.bump(remainder[0..total_len].len());
             return true;
         }
     }
@@ -242,7 +242,7 @@ fn lex_multi_line_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
     for c in remainder.chars() {
         if quotes_found {
             if c != '\'' {
-                lex.bump(remainder[0..total_len].as_bytes().len());
+                lex.bump(remainder[0..total_len].len());
                 return true;
             } else {
                 if quote_count > 4 {
@@ -269,7 +269,7 @@ fn lex_multi_line_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
 
     // End of input
     if quotes_found {
-        lex.bump(remainder[0..total_len].as_bytes().len());
+        lex.bump(remainder[0..total_len].len());
         true
     } else {
         false


### PR DESCRIPTION
Closes #619

A pragmatic and practical fix to slow performance on directories with large `target` dirs et.al. (form _doesn't terminate_ to _milliseconds_ for 100GB+ `target` directory)

Also avoids a bunch of unnecessary `collect`ions and passes around an iterator instead, with the according file rename.