### PR TITLE
improve error locations for unexpected properties

### DIFF
--- a/crates/taplo-cli/src/printing.rs
+++ b/crates/taplo-cli/src/printing.rs
@@ -123,7 +123,7 @@ impl<E: Environment> Taplo<E> {
         let mut out_diag = Vec::<u8>::new();
         for err in errors {
             let msg = err.error.to_string();
-            for text_range in err.node.text_ranges() {
+            for text_range in err.text_ranges() {
                 let diag = Diagnostic::error()
                     .with_message(err.error.to_string())
                     .with_labels(Vec::from([

--- a/crates/taplo-lsp/src/handlers/document_symbols.rs
+++ b/crates/taplo-lsp/src/handlers/document_symbols.rs
@@ -58,11 +58,11 @@ fn symbols_for_value(
     mapper: &Mapper,
     symbols: &mut Vec<DocumentSymbol>,
 ) {
-    let own_range = mapper.range(join_ranges(node.text_ranges())).unwrap();
+    let own_range = mapper.range(join_ranges(node.text_ranges(true))).unwrap();
 
     let range = if let Some(key_r) = key_range {
         mapper
-            .range(key_r.cover(join_ranges(node.text_ranges())))
+            .range(key_r.cover(join_ranges(node.text_ranges(true))))
             .unwrap()
     } else {
         own_range

--- a/crates/taplo-lsp/src/query.rs
+++ b/crates/taplo-lsp/src/query.rs
@@ -469,8 +469,8 @@ fn full_range(keys: &Keys, node: &Node) -> TextRange {
         .last()
         .map(Key::text_ranges)
     else {
-        return join_ranges(node.text_ranges());
+        return join_ranges(node.text_ranges(true));
     };
 
-    join_ranges(last_key.chain(node.text_ranges()))
+    join_ranges(last_key.chain(node.text_ranges(true)))
 }

--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -318,7 +318,7 @@ where
         let matched = dom.find_all_matches(keys, false)?;
 
         for (_, node) in matched {
-            s.extend(node.text_ranges().map(|r| (r, opts.clone())));
+            s.extend(node.text_ranges(false).map(|r| (r, opts.clone())));
         }
     }
 


### PR DESCRIPTION
## Why
At replit we use taplo for providing lsp support for our [`.replit` configuration file](https://docs.replit.com/replit-workspace/configuring-repl#replit-file) in Repls. We love Taplo!

However, when an unexpected property appears that's invalid according to `additionalProperties: false` from the corresponding JSON schema, the LSP highlights the whole file!

for example, making invalid changes to this valid `.replit` file i used for a [throwaway Repl I made when debugging this issue](https://replit.com/t/replit/onreplit/repls/japlo/view):
```toml
run = "cargo run -- /etc/replit/dotreplit.schema.json dotreplit.json"
modules = ["rust-stable"]

[nix]
channel = "stable-24_05"
```

results in this UX:
![image](https://github.com/user-attachments/assets/8d6831f8-032c-4616-8777-1a6c5eb7d522)

note in this screenshot that the diagnostics are collated to the first diagnostic range, which is the whole file:
![image](https://github.com/user-attachments/assets/c9b5b156-9269-401c-bde7-14bc60ae930f)
![image](https://github.com/user-attachments/assets/a10f0bac-60f4-4f1c-b245-65f18d5543b6)
![image](https://github.com/user-attachments/assets/86e9f139-ccbb-45a3-90a4-0a53e837324f)

those error spans aren't the most helpful, especially that 2nd screenshot 😬

## What changed

1. updated `taplo::dom::Node::text_ranges` method to accept a new argument `include_children: bool` which conditionally recurses into children when the value is true. `true` was the default behavior prior to this change
2. created new `taplo_common::schema::NodeValidationError::text_ranges` method to conditionally pass `false` to the above method.
   - right now, only `jsonschema::error::ValidationErrorKind::AdditionalProperties` errors result in this value being `false`, but it may be desired that other error kinds should result in this value being `false`
   - i wanted to minimize changing behavior in case this resulted in unexpected behavior
3. updated `lint` and `lsp` commands to use the new `NodeValidationError::text_ranges` method instead of `Node::text_ranges`
4. all other calls to `Node::text_ranges` pass `true` as the parameter to minimize unexpected behavior

this results in this new behavior:
![image](https://github.com/user-attachments/assets/c57b22e1-2e5d-47cb-81cb-1564e0474da3)
![image](https://github.com/user-attachments/assets/1f242af0-1e49-45f9-9008-553ecc1170b2)
