### PR TITLE
fix incorrect error locations

### DIFF
--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -717,22 +717,24 @@ impl NodeValidationError {
     }
 
     pub fn text_ranges(&self) -> Box<dyn Iterator<Item = TextRange> + '_> {
-        let include_children = match self.error.kind {
-            ValidationErrorKind::AdditionalProperties { .. } => false,
-            _ => true,
-        };
+        match self.error.kind {
+            ValidationErrorKind::AdditionalProperties { .. } => {
+                let include_children = false;
 
-        if self.keys.is_empty() {
-            return Box::new(self.node.text_ranges(include_children).into_iter());
+                if self.keys.is_empty() {
+                    return Box::new(self.node.text_ranges(include_children).into_iter());
+                }
+
+                Box::new(
+                    self.keys
+                        .clone()
+                        .into_iter()
+                        .map(move |key| self.node.get(key).text_ranges(include_children))
+                        .flatten(),
+                )
+            }
+            _ => Box::new(self.node.text_ranges(true)),
         }
-
-        Box::new(
-            self.keys
-                .clone()
-                .into_iter()
-                .map(move |key| self.node.get(key).text_ranges(include_children))
-                .flatten(),
-        )
     }
 }
 


### PR DESCRIPTION
#664 handles `AnyOf` validation error kind incorrectly so that the error span is always `(0,0)`.

![Screenshot_20240921_035830](https://github.com/user-attachments/assets/3d2a10cc-edac-44ad-9f79-63c16d9afa4d)

This PR ensures that PR only influences `AdditionalProperties`.