### PR TITLE
Change the string token parsing to bump by `total_len`, instead of `remainder[0..total_len].as_bytes().len()`

### DIFF
--- a/crates/taplo/src/syntax.rs
+++ b/crates/taplo/src/syntax.rs
@@ -141,7 +141,7 @@ fn lex_string(lex: &mut Lexer<SyntaxKind>) -> bool {
         }
 
         if c == '"' && !escaped {
-            lex.bump(remainder[0..total_len].as_bytes().len());
+            lex.bump(total_len);
             return true;
         }
 
@@ -171,7 +171,7 @@ fn lex_multi_line_string(lex: &mut Lexer<SyntaxKind>) -> bool {
                     return false;
                 }
 
-                lex.bump(remainder[0..total_len].as_bytes().len());
+                lex.bump(total_len);
                 return true;
             } else {
                 quote_count += 1;
@@ -205,7 +205,7 @@ fn lex_multi_line_string(lex: &mut Lexer<SyntaxKind>) -> bool {
             return false;
         }
 
-        lex.bump(remainder[0..total_len].as_bytes().len());
+        lex.bump(total_len);
         true
     } else {
         false
@@ -220,7 +220,7 @@ fn lex_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
         total_len += c.len_utf8();
 
         if c == '\'' {
-            lex.bump(remainder[0..total_len].as_bytes().len());
+            lex.bump(total_len);
             return true;
         }
     }
@@ -242,7 +242,7 @@ fn lex_multi_line_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
     for c in remainder.chars() {
         if quotes_found {
             if c != '\'' {
-                lex.bump(remainder[0..total_len].as_bytes().len());
+                lex.bump(total_len);
                 return true;
             } else {
                 if quote_count > 4 {
@@ -269,7 +269,7 @@ fn lex_multi_line_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
 
     // End of input
     if quotes_found {
-        lex.bump(remainder[0..total_len].as_bytes().len());
+        lex.bump(total_len);
         true
     } else {
         false


### PR DESCRIPTION
Hi, this is my first PR here. I was looking through how `taplo` parses inputs, and saw the string parsing functions could be slightly optimized.

To explain my thought process for this change:
* When parsing for a string in inputs, `taplo` iterates over each character, adding `c.len_utf8()` to a variable called `total_len`. https://github.com/tamasfe/taplo/blob/6694969522c85ae89088bc8d12ddad436f2a26e9/crates/taplo/src/syntax.rs#L136
* `char::len_utf8()` returns the number of bytes that character would need in UTF-8. https://doc.rust-lang.org/1.70.0/std/primitive.char.html#method.len_utf8
* Later, when we finish parsing the string, we bump the end of the currently lexed token by `remainder[0..total_len].as_bytes().len()` bytes. https://github.com/tamasfe/taplo/blob/6694969522c85ae89088bc8d12ddad436f2a26e9/crates/taplo/src/syntax.rs#L144
* ...except, `impl SliceIndex<str> for Range<usize>` takes in a start and end point in bytes. https://doc.rust-lang.org/1.70.0/std/primitive.str.html#impl-SliceIndex%3Cstr%3E-for-Range%3Cusize%3E
* This means the length of `remainder[0..total_len]` in bytes will always be `total_len`. Thus, we can just replace `remainder[0..total_len].as_bytes().len()` with `total_len`.

I was not able to test this PR locally, as `cargo test` would fail due to issues compiling `pprof` on my Windows machine, but I did use a separate branch in my fork to run the GitHub workflows, which you can see the results of here: https://github.com/LikeLakers2/taplo/actions/runs/10974635267

If I missed anything, or if my thought process is wrong, please let me know. :) Thank you in advance for reviewing my PR! 