### PR TITLE
pass include_children = true to text_ranges in formatting

### DIFF
--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -324,7 +324,7 @@ where
         let matched = dom.find_all_matches(keys, false)?;
 
         for (_, node) in matched {
-            s.extend(node.text_ranges(false).map(|r| (r, opts.clone())));
+            s.extend(node.text_ranges(true).map(|r| (r, opts.clone())));
         }
     }
 


### PR DESCRIPTION
#664 passes `include_children = false` to `text_ranges` and this should be a typo.

This typo makes `reorder_arrays` and `reorder_keys` not work in nested tables.