### PR TITLE
Allow zero-padded numbers in identifiers

### DIFF
--- a/crates/taplo/src/parser/mod.rs
+++ b/crates/taplo/src/parser/mod.rs
@@ -567,9 +567,7 @@ impl<'p> Parser<'p> {
                 }
             }
             FLOAT => {
-                if self.lexer.slice().starts_with('0') {
-                    self.error("zero-padded numbers are not allowed")
-                } else if self.lexer.slice().starts_with('+') {
+                if self.lexer.slice().starts_with('+') {
                     Err(())
                 } else {
                     for (i, s) in self.lexer.slice().split('.').enumerate() {

--- a/crates/taplo/src/tests/mod.rs
+++ b/crates/taplo/src/tests/mod.rs
@@ -27,3 +27,15 @@ fn comments_after_tables() {
 
     assert!(errors.is_empty(), "{:#?}", errors);
 }
+
+#[test]
+fn digits_in_keys() {
+    let src = r#"
+0123 = true
+01.23 = true
+23.01 = true
+"#;
+    let errors = parse(src).errors;
+
+    assert!(errors.is_empty(), "{:#?}", errors);
+}


### PR DESCRIPTION
The TOML standard does not forbid number-like keys starting with zero.

[According to the toml standard](https://toml.io/en/v1.0.0#keys), bare keys may only contain the characters A-Za-z0-9_- and are explicitly allowed to be composed of only ASCII digits. Keys are always interpreted as strings.

![image](https://github.com/user-attachments/assets/f92cafc5-ae09-49d7-9495-4d4530c34908)
