### PR TITLE
Allow dates in identifiers

### DIFF
--- a/crates/taplo/src/parser/mod.rs
+++ b/crates/taplo/src/parser/mod.rs
@@ -584,6 +584,7 @@ impl<'p> Parser<'p> {
                 }
             }
             BOOL => self.token_as(IDENT),
+            DATE => self.token_as(IDENT),
             _ => self.error("expected identifier"),
         }
     }

--- a/crates/taplo/src/tests/mod.rs
+++ b/crates/taplo/src/tests/mod.rs
@@ -27,3 +27,17 @@ fn comments_after_tables() {
 
     assert!(errors.is_empty(), "{:#?}", errors);
 }
+
+#[test]
+fn dates_in_table_keys() {
+    let src = r#"
+[2024-01-01]
+2024-01-01 = true
+
+[[2024-01-02]]
+2024-01-01 = true
+"#;
+    let errors = parse(src).errors;
+
+    assert!(errors.is_empty(), "{:#?}", errors);
+}


### PR DESCRIPTION
According to the toml standard, bare keys may only contain the characters A-Za-z0-9_- and they must contain at least one character. This allows identifiers to look like dates, e.g. 2024-01-01.

Due to a bug in the lexing library logos, some-like identifiers are incorrectly being parsed as INTEGER tokens, while date-like identifiers in table names are being parsed as DATE tokens as they should be. Due to this bug, date-like identifiers were being accepted in some situations by taplo while they were rejected in other situations.

This commit only allows DATE tokens in identifiers (as they should be, according to the standard). It does not fix the underlying bug that sometimes produces incorrect INTEGER tokens instead of DATE tokens.