### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/lsp-async-stub/src/handler.rs
+++ b/crates/lsp-async-stub/src/handler.rs
@@ -8,8 +8,6 @@ use std::marker::PhantomData;
 
 #[async_trait(?Send)]
 pub(crate) trait Handler<W: Clone> {
-    fn method(&self) -> &'static str;
-
     async fn handle(
         &mut self,
         context: Context<W>,
@@ -72,10 +70,6 @@ where
     F: Future<Output = Result<R::Result, rpc::Error>> + 'static,
     W: Clone + 'static,
 {
-    fn method(&self) -> &'static str {
-        R::METHOD
-    }
-
     async fn handle(
         &mut self,
         context: Context<W>,
@@ -160,10 +154,6 @@ where
     F: Future + 'static,
     W: Clone + 'static,
 {
-    fn method(&self) -> &'static str {
-        N::METHOD
-    }
-
     async fn handle(
         &mut self,
         context: Context<W>,

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -53,7 +53,7 @@ impl<E: Environment> Taplo<E> {
             }
         }
 
-        if matches!(cmd.files.get(0).map(|it| it.as_str()), Some("-")) {
+        if matches!(cmd.files.first().map(|it| it.as_str()), Some("-")) {
             self.lint_stdin(cmd).await
         } else {
             self.lint_files(cmd).await

--- a/crates/taplo-cli/src/commands/toml_test.rs
+++ b/crates/taplo-cli/src/commands/toml_test.rs
@@ -90,7 +90,7 @@ impl<'a> TomlTestValue<'a> {
     }
 }
 
-impl<'a> Serialize for TomlTestValue<'a> {
+impl Serialize for TomlTestValue<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/taplo-common/src/config.rs
+++ b/crates/taplo-common/src/config.rs
@@ -129,7 +129,7 @@ impl Config {
     pub fn format_scopes<'s>(
         &'s self,
         path: &'s Path,
-    ) -> impl Iterator<Item = (&String, taplo::formatter::OptionsIncomplete)> + Clone + 's {
+    ) -> impl Iterator<Item = (&'s String, taplo::formatter::OptionsIncomplete)> + Clone + 's {
         self.rules_for(path)
             .filter_map(|rule| match (&rule.keys, &rule.options.formatting) {
                 (Some(keys), Some(opts)) => Some(keys.iter().map(move |k| (k, opts.clone()))),

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -716,21 +716,21 @@ impl NodeValidationError {
         Ok(Self { keys, node, error })
     }
 
+    #[must_use]
     pub fn text_ranges(&self) -> Box<dyn Iterator<Item = TextRange> + '_> {
         match self.error.kind {
             ValidationErrorKind::AdditionalProperties { .. } => {
                 let include_children = false;
 
                 if self.keys.is_empty() {
-                    return Box::new(self.node.text_ranges(include_children).into_iter());
+                    return Box::new(self.node.text_ranges(include_children));
                 }
 
                 Box::new(
                     self.keys
                         .clone()
                         .into_iter()
-                        .map(move |key| self.node.get(key).text_ranges(include_children))
-                        .flatten(),
+                        .flat_map(move |key| self.node.get(key).text_ranges(include_children)),
                 )
             }
             _ => Box::new(self.node.text_ranges(true)),

--- a/crates/taplo-common/src/util.rs
+++ b/crates/taplo-common/src/util.rs
@@ -62,13 +62,13 @@ impl PartialEq for ArcHashValue {
 #[derive(Eq)]
 pub struct HashValue<'v>(pub &'v Value);
 
-impl<'v> PartialEq for HashValue<'v> {
+impl PartialEq for HashValue<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<'v> Hash for HashValue<'v> {
+impl Hash for HashValue<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match &self.0 {
             Value::Null => 0.hash(state),
@@ -126,10 +126,10 @@ pub fn get_reqwest_client(timeout: std::time::Duration) -> Result<reqwest::Clien
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     fn get_certs(
         mut builder: reqwest::ClientBuilder,
-        path: std::ffi::OsString,
+        path: &std::ffi::OsStr,
     ) -> reqwest::ClientBuilder {
         fn get_cert(path: &Path) -> Result<reqwest::Certificate, anyhow::Error> {
-            let is_der = path.extension().map_or(false, |ext| ext == "der");
+            let is_der = path.extension().is_some_and(|ext| ext == "der");
             let buf = std::fs::read(path)?;
             tracing::info!(
                 "Found a custom CA {}. Reading the CA...",
@@ -156,7 +156,7 @@ pub fn get_reqwest_client(timeout: std::time::Duration) -> Result<reqwest::Clien
     #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
     fn get_certs(
         builder: reqwest::ClientBuilder,
-        path: std::ffi::OsString,
+        path: &std::ffi::OsStr,
     ) -> reqwest::ClientBuilder {
         tracing::error!(?path, "Could not load certs, taplo was built without TLS");
         builder
@@ -164,7 +164,7 @@ pub fn get_reqwest_client(timeout: std::time::Duration) -> Result<reqwest::Clien
 
     let mut builder = reqwest::Client::builder().timeout(timeout);
     if let Some(path) = std::env::var_os("TAPLO_EXTRA_CA_CERTS") {
-        builder = get_certs(builder, path);
+        builder = get_certs(builder, &path);
     }
     builder.build()
 }

--- a/crates/taplo-lsp/src/handlers/completion.rs
+++ b/crates/taplo-lsp/src/handlers/completion.rs
@@ -84,7 +84,7 @@ pub async fn completion<E: Environment>(
                         || s["type"] == "object"
                         || s["type"]
                             .as_array()
-                            .map_or(false, |arr| arr.iter().any(|v| v == "object"))
+                            .is_some_and(|arr| arr.iter().any(|v| v == "object"))
                 })
             }) {
             Ok(s) => s,
@@ -113,8 +113,7 @@ pub async fn completion<E: Environment>(
                 .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
                     Some(n) => {
                         node.0 == *full_key
-                            || n.as_table()
-                                .map_or(false, |t| t.kind() == TableKind::Pseudo)
+                            || n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo)
                     }
                     None => true,
                 })
@@ -209,9 +208,7 @@ pub async fn completion<E: Environment>(
                 .into_iter()
                 // Filter out existing items.
                 .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
-                    Some(n) => n
-                        .as_table()
-                        .map_or(false, |t| t.kind() == TableKind::Pseudo),
+                    Some(n) => n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                     None => true,
                 })
                 .map(|(_, relative_keys, schema)| CompletionItem {
@@ -318,9 +315,7 @@ pub async fn completion<E: Environment>(
                     .into_iter()
                     // Filter out existing items.
                     .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
-                        Some(n) => n
-                            .as_table()
-                            .map_or(false, |t| t.kind() == TableKind::Pseudo),
+                        Some(n) => n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                         None => true,
                     })
                     .map(|(_, relative_keys, schema)| CompletionItem {
@@ -418,9 +413,7 @@ pub async fn completion<E: Environment>(
             .into_iter()
             // Filter out existing items.
             .filter(|(full_key, _, _)| match doc.dom.path(full_key) {
-                Some(n) => n
-                    .as_table()
-                    .map_or(false, |t| t.kind() == TableKind::Pseudo),
+                Some(n) => n.as_table().is_some_and(|t| t.kind() == TableKind::Pseudo),
                 None => true,
             })
             .map(|(_, relative_keys, schema)| CompletionItem {

--- a/crates/taplo-lsp/src/handlers/hover.rs
+++ b/crates/taplo-lsp/src/handlers/hover.rs
@@ -142,11 +142,7 @@ pub(crate) async fn hover<E: Environment>(
                         s += desc;
                     }
 
-                    let link_title = if let Some(s) = schema["title"].as_str() {
-                        s
-                    } else {
-                        "..."
-                    };
+                    let link_title = schema["title"].as_str().unwrap_or("...");
 
                     if links_in_hover {
                         if let Some(link) = &ext_links.key {
@@ -212,11 +208,7 @@ pub(crate) async fn hover<E: Environment>(
                                     if let Some(enum_docs) = enum_docs.get(idx).cloned().flatten() {
                                         if links_in_hover {
                                             let link_title =
-                                                if let Some(s) = schema["title"].as_str() {
-                                                    s
-                                                } else {
-                                                    "..."
-                                                };
+                                                schema["title"].as_str().unwrap_or("...");
 
                                             if let Some(enum_link) =
                                                 enum_links.get(idx).and_then(Option::as_ref)

--- a/crates/taplo-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/taplo-lsp/src/handlers/semantic_tokens.rs
@@ -86,7 +86,7 @@ pub fn create_tokens(syntax: &SyntaxNode, mapper: &Mapper) -> Vec<SemanticToken>
                         .parent()
                         .and_then(|p| p.next_sibling())
                         .and_then(|t| t.first_child())
-                        .map_or(false, |t| t.kind() == INLINE_TABLE);
+                        .is_some_and(|t| t.kind() == INLINE_TABLE);
 
                     if is_table_key {
                         builder.add_token(&token, TokenType::TomlTableKey, &[]);
@@ -98,7 +98,7 @@ pub fn create_tokens(syntax: &SyntaxNode, mapper: &Mapper) -> Vec<SemanticToken>
                         .parent()
                         .and_then(|p| p.next_sibling())
                         .and_then(|t| t.first_child())
-                        .map_or(false, |t| t.kind() == ARRAY);
+                        .is_some_and(|t| t.kind() == ARRAY);
 
                     if is_array_key {
                         builder.add_token(&token, TokenType::TomlArrayKey, &[]);

--- a/crates/taplo-wasm/src/environment.rs
+++ b/crates/taplo-wasm/src/environment.rs
@@ -43,17 +43,7 @@ impl AsyncRead for JsAsyncRead {
                 }
             };
 
-            let promise = match Promise::try_from(ret) {
-                Ok(p) => p,
-                Err(err) => {
-                    return Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("{:?}", err),
-                    )));
-                }
-            };
-
-            self.fut = Some(JsFuture::from(promise));
+            self.fut = Some(JsFuture::from(Promise::from(ret)));
         }
 
         if let Some(fut) = self.fut.as_mut() {
@@ -113,17 +103,7 @@ impl AsyncWrite for JsAsyncWrite {
                 }
             };
 
-            let promise = match Promise::try_from(ret) {
-                Ok(p) => p,
-                Err(err) => {
-                    return Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("{:?}", err),
-                    )));
-                }
-            };
-
-            self.fut = Some(JsFuture::from(promise));
+            self.fut = Some(JsFuture::from(Promise::from(ret)));
         }
 
         if let Some(fut) = self.fut.as_mut() {

--- a/crates/taplo-wasm/src/lib.rs
+++ b/crates/taplo-wasm/src/lib.rs
@@ -1,3 +1,6 @@
+// Silence errors produced by the #[wasm_bindgen] macro.
+#![allow(unexpected_cfgs)]
+
 use environment::WasmEnvironment;
 use serde::Serialize;
 use std::path::Path;
@@ -213,7 +216,6 @@ pub async fn run_cli(env: JsValue, args: JsValue) -> Result<(), JsError> {
 #[cfg(feature = "lsp")]
 #[wasm_bindgen]
 pub fn create_lsp(env: JsValue, lsp_interface: JsValue) -> lsp::TaploWasmLsp {
-    use taplo_common::environment::Environment;
     use taplo_common::log::setup_stderr_logging;
 
     let env = WasmEnvironment::from(env);

--- a/crates/taplo/src/dom/index.rs
+++ b/crates/taplo/src/dom/index.rs
@@ -50,8 +50,8 @@ impl Index for String {
     }
 }
 
-impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
-impl<'a, T> Index for &'a T
+impl<T> Sealed for &T where T: ?Sized + Sealed {}
+impl<T> Index for &T
 where
     T: ?Sized + Index,
 {

--- a/crates/taplo/src/dom/node.rs
+++ b/crates/taplo/src/dom/node.rs
@@ -180,7 +180,7 @@ impl Node {
         &self,
         keys: Keys,
         include_children: bool,
-    ) -> Result<impl Iterator<Item = (Keys, Node)> + ExactSizeIterator, Error> {
+    ) -> Result<impl ExactSizeIterator<Item = (Keys, Node)>, Error> {
         let mut all = self.flat_iter_impl();
 
         let mut err: Option<Error> = None;

--- a/crates/taplo/src/dom/rewrite.rs
+++ b/crates/taplo/src/dom/rewrite.rs
@@ -129,6 +129,12 @@ pub enum Error {
     Dom(#[from] dom::error::Error),
 }
 
+fn std_range(range: TextRange) -> Range<usize> {
+    let start: usize = u32::from(range.start()) as usize;
+    let end: usize = u32::from(range.end()) as usize;
+    start..end
+}
+
 #[cfg(test)]
 mod tests {
     use super::Rewrite;
@@ -191,10 +197,4 @@ mod tests {
 
         assert_eq!(expected_toml, patches.to_string());
     }
-}
-
-fn std_range(range: TextRange) -> Range<usize> {
-    let start: usize = u32::from(range.start()) as usize;
-    let end: usize = u32::from(range.end()) as usize;
-    start..end
 }

--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -418,10 +418,6 @@ impl FormattedItem for FormattedEntry {
     fn trailing_comment(&self) -> Option<String> {
         self.comment.clone()
     }
-
-    fn syntax(&self) -> SyntaxElement {
-        self.syntax.clone()
-    }
 }
 
 fn format_root(node: SyntaxNode, options: &Options, context: &Context) -> String {
@@ -1202,14 +1198,9 @@ impl<T: AsRef<str>> FormattedItem for (SyntaxElement, T, Option<T>) {
     fn trailing_comment(&self) -> Option<String> {
         self.2.as_ref().map(|s| s.as_ref().to_string())
     }
-
-    fn syntax(&self) -> SyntaxElement {
-        self.0.clone()
-    }
 }
 
 trait FormattedItem {
-    fn syntax(&self) -> SyntaxElement;
     #[allow(clippy::ptr_arg)]
     fn write_to(&self, formatted: &mut String, options: &Options);
     fn trailing_comment(&self) -> Option<String>;

--- a/crates/taplo/src/parser/mod.rs
+++ b/crates/taplo/src/parser/mod.rs
@@ -74,7 +74,7 @@ pub(crate) struct Parser<'p> {
     errors: Vec<Error>,
 }
 
-impl<'p> Parser<'p> {
+impl Parser<'_> {
     /// Required for patch syntax
     /// and key matches.
     ///

--- a/crates/taplo/src/syntax.rs
+++ b/crates/taplo/src/syntax.rs
@@ -141,7 +141,7 @@ fn lex_string(lex: &mut Lexer<SyntaxKind>) -> bool {
         }
 
         if c == '"' && !escaped {
-            lex.bump(remainder[0..total_len].as_bytes().len());
+            lex.bump(remainder[0..total_len].len());
             return true;
         }
 
@@ -171,7 +171,7 @@ fn lex_multi_line_string(lex: &mut Lexer<SyntaxKind>) -> bool {
                     return false;
                 }
 
-                lex.bump(remainder[0..total_len].as_bytes().len());
+                lex.bump(remainder[0..total_len].len());
                 return true;
             } else {
                 quote_count += 1;
@@ -205,7 +205,7 @@ fn lex_multi_line_string(lex: &mut Lexer<SyntaxKind>) -> bool {
             return false;
         }
 
-        lex.bump(remainder[0..total_len].as_bytes().len());
+        lex.bump(remainder[0..total_len].len());
         true
     } else {
         false
@@ -220,7 +220,7 @@ fn lex_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
         total_len += c.len_utf8();
 
         if c == '\'' {
-            lex.bump(remainder[0..total_len].as_bytes().len());
+            lex.bump(remainder[0..total_len].len());
             return true;
         }
     }
@@ -242,7 +242,7 @@ fn lex_multi_line_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
     for c in remainder.chars() {
         if quotes_found {
             if c != '\'' {
-                lex.bump(remainder[0..total_len].as_bytes().len());
+                lex.bump(remainder[0..total_len].len());
                 return true;
             } else {
                 if quote_count > 4 {
@@ -269,7 +269,7 @@ fn lex_multi_line_string_literal(lex: &mut Lexer<SyntaxKind>) -> bool {
 
     // End of input
     if quotes_found {
-        lex.bump(remainder[0..total_len].as_bytes().len());
+        lex.bump(remainder[0..total_len].len());
         true
     } else {
         false

--- a/crates/taplo/src/util/shared.rs
+++ b/crates/taplo/src/util/shared.rs
@@ -53,7 +53,7 @@ where
     }
 
     pub(crate) fn update(&self, f: impl FnOnce(&mut T)) {
-        let mut inner = self.0.load_full().take().unwrap();
+        let mut inner = self.0.load_full().unwrap();
         f(Arc::make_mut(&mut inner));
         self.0.store(Some(inner))
     }


### PR DESCRIPTION
This PR fixes almost all `cargo clippy` warnings.

The remaining warnings are that some `Arc`s in `lsp-async-stub` could be `Rc`s instead. I've replaced *all* `Arc`s in `crates/lsp-async-stub/src/lib.rs` with `Rc`s and everything still compiled without issues with `tokio-stdio` and `tokio-tcp` enabled, so you could probably go further and replace the `AtomicBool` etc. as well, but that's out of scope for this PR.