### PR TITLE
Support "2024" edition of Rust.

### DIFF
--- a/site/site/public/schemas/Cargo.toml.json
+++ b/site/site/public/schemas/Cargo.toml.json
@@ -430,7 +430,7 @@
       "title": "Edition",
       "description": "The `edition` key affects which edition your package is compiled with. Cargo\nwill always generate packages via [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html) with the `edition` key set to the\nlatest edition. Setting the `edition` key in `[package]` will affect all\ntargets/crates in the package, including test suites, benchmarks, binaries,\nexamples, etc.",
       "type": "string",
-      "enum": ["2015", "2018", "2021"],
+      "enum": ["2015", "2018", "2021", "2024"],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/stable/edition-guide/introduction.html"


### PR DESCRIPTION
The "2024" edition of Rust releases with Rust 1.85.
This updates the schema for Cargo.toml to allow for projects using this edition.