### PR TITLE
[taplo-common] fix infinite recursion with composed allOfs

### DIFF
--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -9,6 +9,12 @@ homepage     = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
 
+[dev-dependencies]
+tokio = { version = "1.24.2", features = [
+  "macros",
+  "test-util",
+] }
+
 [features]
 # default-tls enables native-tls but without enabling native-tls specific features.
 native-tls = ["reqwest/default-tls"]

--- a/test-data/schemas/all-of-composed.json
+++ b/test-data/schemas/all-of-composed.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "duration": {
+            "allOf": [
+                {
+                  "$ref": "#/definitions/Duration"
+                }
+            ]
+        }
+    },
+    "definitions": {
+        "Duration": {
+            "title": "Duration",
+            "description": "A duration, specified in a human-readable format.",
+            "examples": [
+                "60s",
+                "1w 3d"
+            ],
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
(rebasing and re-doing #644)

Hi there!

I was trying to write a schema for [nextest's configuration](https://nexte.st/docs/configuration/), and I ran into a call stack exhaustion issue. It turned out to be because an `allOf` wasn't getting removed even though there was an attempt to do so, leading to infinite recursion.

I couldn't find any tests for schemas so I added some. Please let me know if I can rearrange this to your liking somehow, thanks!

(And once this is landed a release would be lovely -- this is a hard blocker for nextest's schema at the moment.)