### PR TITLE
clear vscode extensions

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -16,3 +16,7 @@ node_modules
 .yarnrc.yml
 rollup-config.js
 scripts/
+node.tsconfig.json
+rollup.config.browser-extension.mjs
+rollup.config.browser-server.mjs
+rollup.config.mjs


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2d50e11a-cb5e-4e0b-bc9f-76d8c7536178)

This appears to be a development-only script, not needed at runtime. If relying on a blacklist makes it easy to miss things, a whitelisting approach might be more reliable. For a similar concept, see the discussion here: <https://github.com/microsoft/vscode-vsce/issues/12>.