### PR TITLE
fix: remove all the array index keys when there is more than one

### DIFF
--- a/crates/taplo-lsp/src/handlers/hover.rs
+++ b/crates/taplo-lsp/src/handlers/hover.rs
@@ -112,7 +112,7 @@ pub(crate) async fn hover<E: Environment>(
             keys = lookup_keys(doc.dom.clone(), &keys);
 
             // We're interested in the array itself, not its item type.
-            if let Some(KeyOrIndex::Index(_)) = keys.iter().last() {
+            while let Some(KeyOrIndex::Index(_)) = keys.iter().last() {
                 keys = keys.skip_right(1);
             }
 


### PR DESCRIPTION
The `Query::position_info_at()` function can return one index when the value is a non-empty array. In this case, the `Query::lookup_keys()` function will add another one, resulting in two index keys. But the code was only removing one, causing hover to break for keys with a non-empty array value.

This change avoids the issue by removing index keys in a while loop.

Closes #788