### PR TITLE
feat(action): add github action for cargo.toml formating

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,36 @@
+name: "cargo.toml fmt"
+author: "Gwen Lg"
+description: "Run TOML formatting change or check on Cargo.toml in GitHub Actions"
+
+inputs:
+  version:
+    description: "Version of Taplo"
+    required: false
+    default: "0.9.3"
+
+  files:
+    description: "Files or patterns to check"
+    required: false
+    default: "Cargo.toml"
+
+  write_changes:
+    description: "Do the formatting and write changes to the repository"
+    required: false
+    default: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Taplo
+      id: fmt
+      shell: bash
+      env:
+        INSTALL_DIR: .
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_FILES: ${{ inputs.files }}
+        INPUT_WRITE_CHANGES: ${{ inputs.write_changes }}
+      run: $GITHUB_ACTION_PATH/action/entrypoint.sh
+
+branding:
+  icon: "type"
+  color: "red"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -eu
+
+SOURCE_DIR="$(dirname -- ${BASH_SOURCE[0]:-$0})"
+
+log() {
+    echo -e "$1" >&2
+}
+
+_DEFAULT_INSTALL_DIR=${HOME}/bin
+_INSTALL_DIR=${INSTALL_DIR:-${_DEFAULT_INSTALL_DIR}}
+CMD_NAME="taplo"
+COMMAND="${_INSTALL_DIR}/${CMD_NAME}"
+
+TARGET=${INPUT_FILES:-"."}
+if [[ -z $(ls ${TARGET} 2>/dev/null) ]]; then
+    log "ERROR: Input files (${TARGET}) not found"
+    exit 1
+fi
+
+if [[ ! -x ${COMMAND} ]]; then
+    VERSION=${INPUT_VERSION:-"0.9.3"}
+    if [[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]]; then
+        ARCH="aarch64"
+    else
+        ARCH="x86_64"
+    fi
+    UNAME=$(uname -s)
+    if [[ "$UNAME" == "Darwin" ]]; then
+        TARGET_FILE="full-darwin-${ARCH}"
+        FILE_EXT="gz"
+    elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]]; then
+        TARGET_FILE="windows-${ARCH}"
+        FILE_EXT="zip"
+    else
+        TARGET_FILE="linux-${ARCH}"
+        FILE_EXT="gz"
+    fi
+    FILE_NAME="${CMD_NAME}-${TARGET_FILE}.${FILE_EXT}"
+    log "Downloading '${CMD_NAME}' v${VERSION}"
+    wget --progress=dot:mega "https://github.com/tamasfe/taplo/releases/download/${VERSION}/${FILE_NAME}"
+
+    mkdir -p ${_INSTALL_DIR}
+    if [[ "$FILE_EXT" == "zip" ]]; then
+        unzip -o "${FILE_NAME}" -d ${_INSTALL_DIR} ${CMD_NAME}.exe
+    else
+        gzip -d "${FILE_NAME}" -c >${COMMAND}
+        chmod +x ${COMMAND}
+    fi
+    rm "${FILE_NAME}"
+fi
+log "jq: $(jq --version)"
+
+ARGS="format"
+# Write changes to the repository
+if [ "${INPUT_WRITE_CHANGES:-false}" == "false" ]; then
+    ARGS+=" --check --diff"
+fi
+ARGS+=" ${TARGET}"
+
+log "$ ${COMMAND} ${ARGS}"
+${COMMAND} ${ARGS}


### PR DESCRIPTION
_Note: this is a first version for comments_

It's great to have Cargo.toml (by example) formatted on save in VSCode. But If it's not checked in CI, this is dependent of developer use `Even Better TOML` and process.

TODO:
- manage config with `indent_string="    "` for Cargo.toml (like `Even Better TOML`)
- convert output to display beautiful error/warning in github
- feature for allow automatic patch commits ?

#470

Work inspired from https://github.com/marketplace/actions/typos-action