### PR TITLE
Reduce logging verbosity

### DIFF
--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -139,7 +139,8 @@ impl<E: Environment> Taplo<E> {
 
         let excluded = total - files.len();
 
-        tracing::info!(total, excluded, ?files, "found files");
+        tracing::info!(total, excluded, "found files");
+        tracing::debug!(?files, "file details");
 
         Ok(files)
     }


### PR DESCRIPTION
We have a lot of toml files, and by default the CLI emits at INFO level. I would also be happy with a complete approach, e.g. adding a --quiet flag, or only emitting logs at warning level, but this I think is a generally good change.