### PR TITLE
Remove backtrace feature from anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,6 @@ name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arc-swap"

--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -25,7 +25,7 @@ taplo        = { version = "0.14.0", path = "../taplo", features = ["serde"] }
 taplo-common = { version = "0.6.0", path = "../taplo-common" }
 taplo-lsp    = { version = "0.8.0", path = "../taplo-lsp", default-features = false, optional = true }
 
-anyhow             = { workspace = true, features = ["backtrace"] }
+anyhow             = { workspace = true }
 clap               = { workspace = true, features = ["derive", "cargo", "env", "default"] }
 codespan-reporting = { version = "0.11.1" }
 futures            = { workspace = true }

--- a/crates/taplo-common/Cargo.toml
+++ b/crates/taplo-common/Cargo.toml
@@ -20,7 +20,7 @@ reqwest    = ["dep:reqwest"]
 taplo = { version = "0.14.0", path = "../taplo", features = ["schema"] }
 
 ahash              = { workspace = true, features = ["serde"] }
-anyhow             = { workspace = true, features = ["backtrace"] }
+anyhow             = { workspace = true }
 arc-swap           = { workspace = true }
 async-recursion    = { version = "1.0.0" }
 async-trait        = { workspace = true }


### PR DESCRIPTION
On compilers that are Rust 1.65+, the only effect of this feature is bringing in an extra unused dependency for no reason. Taplo does not support compilers older than Rust 1.65. The oldest supported compiler currently is Rust 1.74.