### PR TITLE
fix: use new schemastore catalog url

### DIFF
--- a/crates/taplo-common/src/schema/associations.rs
+++ b/crates/taplo-common/src/schema/associations.rs
@@ -17,7 +17,7 @@ use taplo::dom::Node;
 use tokio::sync::Semaphore;
 use url::Url;
 
-pub const DEFAULT_CATALOGS: &[&str] = &["https://www.schemastore.org/api/json/catalog.json"];
+pub const DEFAULT_CATALOGS: &[&str] = &["https://json.schemastore.org/api/json/catalog.json"];
 
 pub mod priority {
     pub const BUILTIN: usize = 10;

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -233,7 +233,7 @@
             "type": "string"
           },
           "default": [
-            "https://www.schemastore.org/api/json/catalog.json"
+            "https://json.schemastore.org/api/json/catalog.json"
           ]
         },
         "evenBetterToml.schema.associations": {


### PR DESCRIPTION
SchemaStore.org is in the process of transition to GitHub pages hosting. The new, and more canonical, URL for the catalog is:

> https://json.schemastore.org/api/json/catalog.json

though this does require following a redirect.

Ref: SchemaStore/schemastore#4759
Ref: SchemaStore/schemastore#4763
Ref: tamasfe/taplo#800