### PR TITLE
ci: fix release ci for yarn 1.22.22

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -201,6 +201,7 @@ jobs:
           timeout_minutes: 60
           command: cd js/cli && yarn install && yarn publish
         env:
+          RELEASE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   npm_publish_taplo_lsp:
@@ -231,6 +232,7 @@ jobs:
           timeout_minutes: 60
           command: cd js/lsp && yarn install && yarn publish
         env:
+          RELEASE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   npm_publish_taplo_lib:
@@ -261,6 +263,7 @@ jobs:
           timeout_minutes: 60
           command: cd js/lib && yarn install && yarn publish
         env:
+          RELEASE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build_cli_windows:


### PR DESCRIPTION
For yarn classic, `"prepublish": "RELEASE=true yarn build"` will only take effect on child process for `yarn prepublish` because here "RELEASE=true" is a shell variable instead of the environment variable. In yarn berry (2+, 3+, 4+), "RELEASE=true" will be promoted to environment variable. while the github ci (ubuntu-lastest) still use yarn classic, so the `"prepublish": "RELEASE=true yarn build"` will take no effect. There are many solutions:

- update yarn to berry in ci
- use [`cross-env`](https://www.npmjs.com/package/cross-env) to promote "RELEASE=true" to environment variable for yarn classic
- set `"prepublish": "export RELEASE=true; yarn build"` (but this does not work for Windows) or just define the "RELEASE=true" in ci (this commit)

This close #660