### PR TITLE
fix: make --diff work on wasm

### DIFF
--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -25,6 +25,7 @@ taplo        = { version = "0.14.0", path = "../taplo", features = ["serde"] }
 taplo-common = { version = "0.6.0", path = "../taplo-common" }
 taplo-lsp    = { version = "0.8.0", path = "../taplo-lsp", default-features = false, optional = true }
 
+ansi_term          = { version = "0.12" }
 anyhow             = { workspace = true }
 clap               = { workspace = true, features = ["derive", "cargo", "env", "default"] }
 codespan-reporting = { version = "0.11.1" }
@@ -33,6 +34,7 @@ glob               = { workspace = true }
 hex                = { workspace = true }
 itertools          = { workspace = true }
 once_cell          = { workspace = true }
+prettydiff         = { version = "0.6.1", default-features = false }
 regex              = { workspace = true }
 reqwest            = { workspace = true, features = ["json"], optional = true }
 schemars           = { workspace = true }
@@ -47,10 +49,8 @@ url                = { workspace = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 lsp-async-stub = { version = "0.7.0", path = "../lsp-async-stub", features = ["tokio-tcp", "tokio-stdio"] }
 
-ansi_term     = { version = "0.12" }
 async-ctrlc   = { version = "1.2.0", features = ["stream"], optional = true }
 clap_complete = { version = "4.4.18", optional = true }
-prettydiff    = { version = "0.6.1", default-features = false }               # `prettydiff` is also a CLI that pulls in `clap` by default
 
 tokio = { workspace = true, features = ["sync", "fs", "time", "io-std", "rt-multi-thread", "parking_lot"] }
 

--- a/crates/taplo-cli/src/commands/format.rs
+++ b/crates/taplo-cli/src/commands/format.rs
@@ -80,18 +80,6 @@ impl<E: Environment> Taplo<E> {
         Ok(())
     }
 
-    #[cfg(target_arch = "wasm32")]
-    async fn print_diff(
-        &self,
-        _path: impl AsRef<Path>,
-        _original: &str,
-        _formatted: &str,
-    ) -> Result<(), anyhow::Error> {
-        tracing::warn!("the `--diff` flag is not available in this build yet");
-        Ok(())
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
     async fn print_diff(
         &self,
         path: impl AsRef<Path>,


### PR DESCRIPTION
`--diff` is disabled in #311 (IIUC because `tokio` does not compile on wasm at that time?) But now I think it does compile, so I propose adding `--diff` back.

<details><summary>For reference if needed: my use case</summary>
<p>

My use case is in the CI of a node project, which needs `--diff` so that people can know exactly which lines to change. Without this feature in wasm I have to download a separate taplo binary (it's fine but slighly more complex), instead of putting it in dev dependencies and install along with all other packages.

</p>
</details> 