### PR TITLE
chore: add completions for nushell and fig with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,11 +363,31 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.3"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a2d6eec27fce550d708b2be5d798797e5a55b246b323ef36924a0001996352"
+checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d494102c8ff3951810c72baf96910b980fb065ca5d3101243e6a8dc19747c86b"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce"
+dependencies = [
+ "clap",
+ "clap_complete",
 ]
 
 [[package]]
@@ -2251,6 +2271,8 @@ dependencies = [
  "async-ctrlc",
  "clap",
  "clap_complete",
+ "clap_complete_fig",
+ "clap_complete_nushell",
  "codespan-reporting",
  "futures",
  "glob",

--- a/crates/taplo-cli/Cargo.toml
+++ b/crates/taplo-cli/Cargo.toml
@@ -18,7 +18,7 @@ lsp         = ["async-ctrlc", "lint", "taplo-lsp"]
 native-tls  = ["taplo-common/native-tls", "taplo-lsp?/native-tls"]
 rustls-tls  = ["taplo-common/rustls-tls", "taplo-lsp?/rustls-tls"]
 toml-test   = ["lint"]
-completions = ["dep:clap_complete"]
+completions = ["dep:clap_complete", "dep:clap_complete_fig", "dep:clap_complete_nushell"]
 
 [dependencies]
 taplo        = { version = "0.14.0", path = "../taplo", features = ["serde"] }
@@ -47,10 +47,12 @@ url                = { workspace = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 lsp-async-stub = { version = "0.7.0", path = "../lsp-async-stub", features = ["tokio-tcp", "tokio-stdio"] }
 
-ansi_term     = { version = "0.12" }
-async-ctrlc   = { version = "1.2.0", features = ["stream"], optional = true }
-clap_complete = { version = "4.4.18", optional = true }
-prettydiff    = { version = "0.6.1", default-features = false }               # `prettydiff` is also a CLI that pulls in `clap` by default
+ansi_term             = { version = "0.12" }
+async-ctrlc           = { version = "1.2.0", features = ["stream"], optional = true }
+clap_complete         = { version = "4.4.18", optional = true }
+clap_complete_nushell = { version = "4.5.8", optional = true }
+clap_complete_fig     = { version = "4.5.2", optional = true }
+prettydiff            = { version = "0.6.1", default-features = false }               # `prettydiff` is also a CLI that pulls in `clap` by default
 
 tokio = { workspace = true, features = ["sync", "fs", "time", "io-std", "rt-multi-thread", "parking_lot"] }
 

--- a/crates/taplo-cli/src/commands/mod.rs
+++ b/crates/taplo-cli/src/commands/mod.rs
@@ -26,20 +26,80 @@ impl<E: Environment> Taplo<E> {
 
         match taplo.cmd {
             #[cfg(feature = "completions")]
-            TaploCommand::Completions { shell } => {
+            TaploCommand::Completions { shell: shell_s } => {
                 use anyhow::anyhow;
                 use clap::CommandFactory;
                 use clap_complete::{generate, shells::Shell};
                 use std::{io::stdout, str::FromStr};
 
-                let shell = Shell::from_str(&shell).map_err(|e| anyhow!(e))?;
-                generate(
-                    shell,
-                    &mut TaploArgs::command(),
-                    TaploArgs::command().get_bin_name().unwrap(),
-                    &mut stdout(),
-                );
-                Ok(())
+                let mut cmd = TaploArgs::command();
+                let bin_name = TaploArgs::command()
+                    .get_bin_name()
+                    .unwrap_or("taplo")
+                    .to_string();
+
+                let s = shell_s.to_ascii_lowercase();
+
+                match s.as_str() {
+                    "bash" => {
+                        generate(
+                            clap_complete::Shell::Bash,
+                            &mut cmd,
+                            &bin_name,
+                            &mut stdout(),
+                        );
+                        Ok(())
+                    }
+                    "zsh" | "zsh5" | "zsh6" => {
+                        generate(
+                            clap_complete::Shell::Zsh,
+                            &mut cmd,
+                            &bin_name,
+                            &mut stdout(),
+                        );
+                        Ok(())
+                    }
+                    "fish" => {
+                        generate(
+                            clap_complete::Shell::Fish,
+                            &mut cmd,
+                            &bin_name,
+                            &mut stdout(),
+                        );
+                        Ok(())
+                    }
+                    "powershell" | "pwsh" => {
+                        generate(
+                            clap_complete::Shell::PowerShell,
+                            &mut cmd,
+                            &bin_name,
+                            &mut stdout(),
+                        );
+                        Ok(())
+                    }
+                    "elvish" => {
+                        generate(
+                            clap_complete::Shell::Elvish,
+                            &mut cmd,
+                            &bin_name,
+                            &mut stdout(),
+                        );
+                        Ok(())
+                    }
+
+                    // new: Nushell and Fig
+                    "nushell" | "nu" => {
+                        use clap_complete_nushell::Nushell;
+                        generate(Nushell, &mut cmd, &bin_name, &mut stdout());
+                        Ok(())
+                    }
+                    "fig" => {
+                        use clap_complete_fig::Fig;
+                        generate(Fig, &mut cmd, &bin_name, &mut stdout());
+                        Ok(())
+                    }
+                    other => Err(anyhow!(format!("{other} is not support"))),
+                }
             }
             TaploCommand::Config { cmd } => self.execute_config(cmd).await,
             TaploCommand::Format(fmt) => self.execute_format(fmt).await,


### PR DESCRIPTION
Resolved #812

This PR adds Nushell and fig completion support to Taplo.

No breaking changes.
