### PR TITLE
fix: exclude symlinks from included files

### DIFF
--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -134,7 +134,7 @@ impl<E: Environment> Taplo<E> {
 
         let files = files
             .into_iter()
-            .filter(|path| config.is_included(path))
+            .filter(|path| config.is_included(path) && !path.is_symlink())
             .collect::<Vec<_>>();
 
         let excluded = total - files.len();


### PR DESCRIPTION
I have somewhat of an unusual setup. Because I'm using cargo-fuzz I have symlinked my .rustfmt.toml file from the root directory. I'm not sure why but on GitHub Actions running taplo I get the following output:
```
Run taplo lint --default-schema-catalogs --verbose --colors=always
  2025-10-03T19:59:05.565233Z  INFO taplo_cli: found files, total: 17, excluded: 0, files: ["/home/runner/work/rustcc/rustcc/.clippy.toml", "/home/runner/work/rustcc/rustcc/.rustfmt.toml", "/home/runner/work/rustcc/rustcc/.typos.toml", "/home/runner/work/rustcc/rustcc/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_ast/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_codegen/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_diagnostic/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_driver/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_lexer/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_llvm/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_parser/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/rustcc_source/Cargo.toml", "/home/runner/work/rustcc/rustcc/crates/test-driver/Cargo.toml", "/home/runner/work/rustcc/rustcc/fuzz/.rustfmt.toml", "/home/runner/work/rustcc/rustcc/fuzz/Cargo.toml", "/home/runner/work/rustcc/rustcc/fuzz/toolchain.toml"]
    at crates/taplo-cli/src/lib.rs:142
    in taplo_cli::collect_files with cwd="/home/runner/work/rustcc/rustcc"
    in taplo_cli::commands::lint::lint_files
    in taplo::taplo

  2025-10-03T19:59:05.675028Z ERROR taplo_cli::commands::lint: invalid file, error: No such file or directory (os error 2), path: "/home/runner/work/rustcc/rustcc/fuzz/.rustfmt.toml"
    at crates/taplo-cli/src/commands/lint.rs:87
    in taplo_cli::commands::lint::lint_files
    in taplo::taplo

  2025-10-03T19:59:05.676462Z ERROR taplo: operation failed, error: some files were not valid
    at crates/taplo-cli/bin/taplo.rs:33

Error: Process completed with exit code 1.
```

I cannot reproduce this on my machine as it works just fine there. But I don't think analyzing symlinks is a good idea anyways so this patch simply excludes any symlinks. With this patch the output now looks something like this:
```
2025-10-03T20:16:14.373750Z  INFO taplo_cli: found files, total: 17, excluded: 1, files: ["/mnt/data/dev/rustcc/.clippy.toml", "/mnt/data/dev/rustcc/.rustfmt.toml", "/mnt/data/dev/rustcc/.typos.toml", "/mnt/data/dev/rustcc/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_ast/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_codegen/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_diagnostic/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_driver/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_lexer/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_llvm/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_parser/Cargo.toml", "/mnt/data/dev/rustcc/crates/rustcc_source/Cargo.toml", "/mnt/data/dev/rustcc/crates/test-driver/Cargo.toml", "/mnt/data/dev/rustcc/fuzz/Cargo.toml", "/mnt/data/dev/rustcc/fuzz/toolchain.toml"]
    at crates/taplo-cli/src/lib.rs:142
    in taplo_cli::collect_files with cwd="/mnt/data/dev/rustcc"
    in taplo_cli::commands::lint::lint_files
    in taplo::taplo
```