### PR TITLE
Updates schemastore endpoint

### DIFF
--- a/crates/taplo-common/src/schema/associations.rs
+++ b/crates/taplo-common/src/schema/associations.rs
@@ -504,7 +504,7 @@ pub struct SchemaStoreSchemaMeta {
 }
 
 pub const SCHEMA_STORE_CATALOG_SCHEMA_URL: &str =
-    "https://json.schemastore.org/schema-catalog.json";
+    "https://www.schemastore.org/schema-catalog.json";
 
 #[derive(Debug, Clone, Copy)]
 pub struct SchemaStoreCatalogSchema;

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -233,7 +233,7 @@
             "type": "string"
           },
           "default": [
-            "https://json.schemastore.org/api/json/catalog.json"
+            "https://www.schemastore.org/api/json/catalog.json"
           ]
         },
         "evenBetterToml.schema.associations": {

--- a/site/site/configuration/developing-schemas.md
+++ b/site/site/configuration/developing-schemas.md
@@ -82,7 +82,7 @@ Other than `fileMatch`, it is also possible to specify `regexMatch` that is matc
     "tomlValidation": [
       {
         "regexMatch": "^.*foo.toml$",
-        "url": "https://json.schemastore.org/foo.json"
+        "url": "https://www.schemastore.org/foo.json"
       }
     ]
   }


### PR DESCRIPTION
It seems that Schema Store recently changes their API endpoint to www.schemastore.org, instead of old json.schemastore.org for some reason. For example, although I could not find any actual discussion or announcement, this is stated here: https://github.com/microsoft/vscode/issues/254689.

It seems that json.* subdomain had lived for some duration, but it starts to fail to serve reliably, and results in unexpected linting error.
This PR aims at fixing this just by rewriting schemastore catalog url. I confirmed that this should work by adding following lines to `.taplo.toml`:

```toml
[schema]
path = "https://www.schemastore.org/api/json/catalog.json"
```