### PR TITLE
Fix glob matching bug in `Node::get_matches`

### DIFF
--- a/crates/taplo/src/dom/node.rs
+++ b/crates/taplo/src/dom/node.rs
@@ -124,7 +124,7 @@ impl Node {
             Node::Table(t) => {
                 let entries = t.entries().read();
                 for (key, node) in entries.iter() {
-                    if glob.is_match(pattern) {
+                    if glob.is_match(key.value()) {
                         matched.push((KeyOrIndex::from(key.clone()), node.clone()));
                     }
                 }
@@ -663,3 +663,5 @@ impl From<Invalid> for Node {
         Self::Invalid(v)
     }
 }
+
+

--- a/crates/taplo/src/tests/mod.rs
+++ b/crates/taplo/src/tests/mod.rs
@@ -41,3 +41,24 @@ fn dates_in_table_keys() {
 
     assert!(errors.is_empty(), "{:#?}", errors);
 }
+
+#[test]
+fn get_matches_table_key() {
+    let src = r#"
+name1 = "v"
+other = "v2"
+"#;
+
+    let root = parse(src).into_dom();
+
+    let matched: Vec<String> = root
+        .get_matches("na*")
+        .unwrap()
+        .map(|(k, _)| match k {
+            crate::dom::KeyOrIndex::Key(key) => key.value().to_string(),
+            crate::dom::KeyOrIndex::Index(idx) => idx.to_string(),
+        })
+        .collect();
+
+    assert_eq!(matched, vec!["name1"]);
+}


### PR DESCRIPTION
When working on #840, I stumbled upon some fishy code in `get_matches` (which seems to be untested, currently). If I'm not mistaken, this is a plain bug. I also included a very primitive test.