### PR TITLE
Preserve array formatting when source has trailing comma

### DIFF
--- a/crates/taplo-wasm/src/lib.rs
+++ b/crates/taplo-wasm/src/lib.rs
@@ -213,7 +213,6 @@ pub async fn run_cli(env: JsValue, args: JsValue) -> Result<(), JsError> {
 #[cfg(feature = "lsp")]
 #[wasm_bindgen]
 pub fn create_lsp(env: JsValue, lsp_interface: JsValue) -> lsp::TaploWasmLsp {
-    
     use taplo_common::log::setup_stderr_logging;
 
     let env = WasmEnvironment::from(env);

--- a/crates/taplo/src/formatter/mod.rs
+++ b/crates/taplo/src/formatter/mod.rs
@@ -945,8 +945,20 @@ fn is_array_multiline(node: &SyntaxNode) -> bool {
     node.descendants_with_tokens().any(|n| n.kind() == NEWLINE)
 }
 
+fn has_trailing_comma(node: &SyntaxNode) -> bool {
+    let mut last_significant = None;
+    for child in node.children_with_tokens() {
+        match child.kind() {
+            COMMA | VALUE => last_significant = Some(child.kind()),
+            WHITESPACE | NEWLINE | COMMENT | BRACKET_END => {}
+            _ => {}
+        }
+    }
+    last_significant == Some(COMMA)
+}
+
 fn can_collapse_array(node: &SyntaxNode) -> bool {
-    !node.descendants_with_tokens().any(|n| n.kind() == COMMENT)
+    !node.descendants_with_tokens().any(|n| n.kind() == COMMENT) && !has_trailing_comma(node)
 }
 
 fn format_array(node: SyntaxNode, options: &Options, context: &Context) -> impl FormattedItem {

--- a/crates/taplo/src/tests/formatter.rs
+++ b/crates/taplo/src/tests/formatter.rs
@@ -504,10 +504,10 @@ my_array = [
     [
         [
             [
-                "my_value",
-            ],
-        ],
-    ],
+                "my_value"
+            ]
+        ]
+    ]
 ]
 "#;
 
@@ -520,6 +520,32 @@ my_array = [[[["my_value"]]]]
         formatter::Options {
             array_auto_collapse: true,
             compact_arrays: true,
+            indent_string: "    ".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_format!(expected, &formatted);
+}
+
+#[test]
+fn array_collapse_preserves_trailing_comma() {
+    let src = r#"
+my_array = [
+    "my_value",
+]
+"#;
+
+    let expected = r#"
+my_array = [
+    "my_value",
+]
+"#;
+
+    let formatted = crate::formatter::format(
+        src,
+        formatter::Options {
+            array_auto_collapse: true,
             indent_string: "    ".into(),
             ..Default::default()
         },
@@ -980,7 +1006,7 @@ foo = { b = 2, a = 1 }
 
 bar = [
   { a = 1, b = 2, c = 3 },
-  { b = 2, a = 1, d = 4, e = 5 },
+  { b = 2, a = 1, d = 4, e = 5 }
 ]
 "#;
 


### PR DESCRIPTION
Arrays with trailing commas in the source are now kept multiline instead of being collapsed. This allows users to control array formatting by including or omitting trailing commas.