### PR TITLE
fix(lsp): include request id in error responses

### DIFF
--- a/crates/lsp-async-stub/src/lib.rs
+++ b/crates/lsp-async-stub/src/lib.rs
@@ -383,6 +383,7 @@ impl<W: Clone> Server<W> {
                         rpc::Response::error(
                             rpc::Error::invalid_request().with_data("server is shutting down"),
                         )
+                        .with_request_id(request.id.clone().unwrap())
                         .into_message(),
                     )
                     .await?;
@@ -409,7 +410,11 @@ impl<W: Clone> Server<W> {
                 );
 
                 writer
-                    .send(rpc::Response::error(rpc::Error::server_not_initialized()).into_message())
+                    .send(
+                        rpc::Response::error(rpc::Error::server_not_initialized())
+                            .with_request_id(request.id.clone().unwrap())
+                            .into_message(),
+                    )
                     .await?;
                 return Ok(());
             }


### PR DESCRIPTION
Hello, thanks for taplo! I use it quite often. I was annoyed by the following, so here's a PR with a fix.

Best regards!

## Problem

When Neovim (or any LSP client) sends a `shutdown` request to taplo, the exit is
delayed by ~1 second. The client logs:

```
LSP[taplo]: Error NO_RESULT_CALLBACK_FOUND: {
  error = {
    code = -32600,
    data = "server is shutting down",
    message = "Invalid request"
  },
  id = 0,
  jsonrpc = "2.0"
}
```

## Root cause

In `crates/lsp-async-stub/src/lib.rs`, two error response paths omit
`.with_request_id(...)`, so the response is sent with the hardcoded
default `id: 0` (from `Response::error()` in `rpc.rs`):

1. **"server is shutting down"** (line 381-388) — when a request arrives
   after `shutting_down` is set to `true`
2. **"server not initialized"** (line 412) — when a request arrives
   before initialization

The client cannot match a response with `id: 0` to any pending request,
so it ignores it and waits for a timeout before force-killing the server.

Other error paths in the same function (`method_not_found` at line 483,
shutdown success at line 470) correctly call `.with_request_id()`.

## Fix

Add `.with_request_id(request.id.clone().unwrap())` to both error
response paths, matching the existing pattern.

## Reproduction

```bash
# Create a minimal TOML file
echo '[package]\nname = "test"' > /tmp/test.toml

# Baseline: open a non-TOML file (~0.15s overhead)
time nvim --headless -c "edit /tmp/test.lua" -c "sleep 1" -c "qall" 2>&1

# Bug: open a TOML file (~1.1s overhead due to taplo shutdown delay)
time nvim --headless -c "edit /tmp/test.toml" -c "sleep 1" -c "qall" 2>&1
```

Before fix: the TOML case takes ~2.1s (1s sleep + 1.1s shutdown delay).
After fix: the TOML case should take ~1.15s (1s sleep + ~0.15s overhead),
matching the non-TOML baseline.

## Related

- PR #354 — fixed taplo not responding to shutdown *at all*
- Issue #400 — duplicate of #354