### PR TITLE
Add release attestations for CLI release assets

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -404,9 +404,18 @@ jobs:
       DEBUG: api
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: |
+            taplo-windows-*/*
+            taplo-macos-*/*
+            taplo-linux-*/*
       - name: Create GitHub release
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -410,6 +410,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - name: Attest build provenance
+        if: github.event_name == 'push'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: |


### PR DESCRIPTION
## Summary
- add GitHub release attestations to the `publish_cli` job in `.github/workflows/releases.yaml`
- grant the job `id-token: write` and `attestations: write`
- attest the Windows, macOS, and Linux Taplo CLI release assets before creating the draft release

## Why
This increases supply-chain security for downstream users consuming Taplo release artifacts.

With release attestations attached to the published CLI assets, tools and workflows can verify that the binaries were produced by Taplo's GitHub Actions release workflow rather than an untrusted source. That is especially useful for consumers installing Taplo through automation such as `mise`, where provenance signals help users and maintainers trust the downloaded binaries.

This mirrors the release attestation pattern already used in `grafana/flint`.

## Impact
- published CLI assets get provenance attestations
- no change to the actual release assets or build outputs
- improves verifiability for automated installers and security-conscious consumers

## Validation
- reviewed the release workflow structure and inserted attestation generation before `gh release create`
- confirmed the change is limited to the `publish_cli` release path
