### PR TITLE
Add package metadata to enable cargo binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,23 @@ strip         = true
 [profile.bench]
 lto       = true
 opt-level = 3
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/release-cli-{ version }/taplo-{ target }.gz"
+bin-dir = "taplo{ binary-ext }"
+pkg-fmt = "gz"
+
+[package.metadata.binstall.overrides.'cfg(all(target_os = "linux", target_arch = "x86_64"))']
+pkg-url = "{ repo }/releases/download/release-cli-{ version }/taplo-linux-x86_64.gz"
+
+[package.metadata.binstall.overrides.'cfg(all(target_os = "linux", target_arch = "aarch64"))']
+pkg-url = "{ repo }/releases/download/release-cli-{ version }/taplo-linux-aarch64.gz"
+
+[package.metadata.binstall.overrides.'cfg(all(target_os = "macos", target_arch = "x86_64"))']
+pkg-url = "{ repo }/releases/download/release-cli-{ version }/taplo-darwin-x86_64.gz"
+
+[package.metadata.binstall.overrides.'cfg(all(target_os = "macos", target_arch = "aarch64"))']
+pkg-url = "{ repo }/releases/download/release-cli-{ version }/taplo-darwin-aarch64.gz"
+
+[package.metadata.binstall.overrides.'cfg(target_os = "windows")']
+pkg-url = "{ repo }/releases/download/release-cli-{ version }/taplo-windows-x86_64.gz"


### PR DESCRIPTION
Add [package.metadata.binstall] so that cargo binstall taplo-cli can resolve the official pre-built release binaries directly, instead of falling through to a source compile.

Note that it was vibe-coded (Claude.ai) and not tested (obviously).
The reason for this tentative-fix, is to improve the situation when trying to `cargo binstall taplo-cli`:
```
$ cargo binstall taplo-cli --force
 INFO resolve: Resolving package: 'taplo-cli'
 WARN resolve: Error while downloading and extracting from fetcher QuickInstall: Failed to download from remote: could not GET https://github.com/cargo-bins/cargo-quickinstall/releases/download/taplo-cli-0.10.0/taplo-cli-0.10.0-x86_64-unknown-linux-gnu.tar.gz: HTTP status client error (404 Not Found) for url (https://github.com/cargo-bins/cargo-quickinstall/releases/download/taplo-cli-0.10.0/taplo-cli-0.10.0-x86_64-unknown-linux-gnu.tar.gz)
 WARN resolve: Error while downloading and extracting from fetcher QuickInstall: Failed to download from remote: could not GET https://github.com/cargo-bins/cargo-quickinstall/releases/download/taplo-cli-0.10.0/taplo-cli-0.10.0-x86_64-unknown-linux-musl.tar.gz: HTTP status client error (404 Not Found) for url (https://github.com/cargo-bins/cargo-quickinstall/releases/download/taplo-cli-0.10.0/taplo-cli-0.10.0-x86_64-unknown-linux-musl.tar.gz)
 WARN The package taplo-cli v0.10.0 will be installed from source (with cargo)
Do you wish to continue? [yes]/no
```
The AI said that taplo is not using the canonical Rust target triple, hence sthis messy patch to try and workaround the situation.